### PR TITLE
fix: adjusted unsupported operand type

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,9 +57,9 @@ PROVIDER_TO_ENV_VAR_KEY = {
 
 # for Minions protocol
 class JobOutput(BaseModel):
-    answer: str | None
-    explanation: str | None
-    citation: str | None
+    answer: str 
+    explanation: str 
+    citation: str 
 
 def extract_text_from_pdf(pdf_bytes):
     """Extract text from a PDF file using PyMuPDF."""

--- a/minions/minions.py
+++ b/minions/minions.py
@@ -57,8 +57,8 @@ class JobManifest(BaseModel):
 
 class JobOutput(BaseModel):
   explanation: str
-  citation: str | None
-  answer: str | None
+  citation: str 
+  answer: str 
 
 def prepare_jobs(
     context: List[str],


### PR DESCRIPTION
When I tried to set this up locally, I encountered an error: `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'` in two files, app.py and minions.py. I had to fix them to allow the Streamlit app to run. 