### PR TITLE
Added energy tracking features!

### DIFF
--- a/app.py
+++ b/app.py
@@ -1470,6 +1470,57 @@ if user_query:
                         f"${total_cost:.4f}",
                         f"{remote_total:,} total tokens",
                     )
+            
+            # Energy usage for both protocols
+            if ("remote_only_energy" in output) and ("minion_local_energy" in output) and ("minion_remote_energy" in output):
+                st.header("Energy Usage")
+                st.markdown("This is the amount of energy saved by running part of the computation locally. We estimate remote energy consumption based on the number of input/output tokens as well as assumptions about the remote model architecture.")
+
+                minion_local_energy = output["minion_local_energy"]
+                minion_remote_energy = output["minion_remote_energy"]
+                minion_energy = minion_local_energy + minion_remote_energy
+
+                remote_only_energy = output["remote_only_energy"]
+
+                energy_savings = remote_only_energy - minion_energy
+
+                c1, c2, c3 = st.columns(3)
+                c1.metric(
+                    f"Minion(s) Energy Consumption",
+                    f"{minion_energy:.2f} J",
+                    None
+                )
+                c2.metric(
+                    f"Remote-Only Energy Consumption",
+                    f"{remote_only_energy:.2f} J",
+                    None
+                )
+                c3.metric(
+                    f"Total Energy Savings!",
+                    f"{energy_savings:.2f} J",
+                    None
+                )
+                # Convert to long format DataFrame for explicit ordering
+                df = pd.DataFrame(
+                    {
+                        "Protocol": [
+                            f"Minion(s)",
+                            f"Minion(s)",
+                            f"Remote-Only",
+                        ],
+                        "Model Type": [
+                            "Remote",
+                            "Local",
+                            "Remote",
+                        ],
+                        "Energy": [
+                            minion_remote_energy,
+                            minion_local_energy,
+                            remote_only_energy,
+                        ],
+                    }
+                )
+                st.bar_chart(df, x="Protocol", y="Energy", color="Model Type")
 
             # Display meta information for minions protocol
             if "meta" in output:

--- a/minions/minion.py
+++ b/minions/minion.py
@@ -6,6 +6,9 @@ from datetime import datetime
 
 from minions.clients import OpenAIClient, TogetherClient
 
+from minions.usage import Usage
+from minions.utils.energy_tracking import PowerMonitor, cloud_inference_energy_estimate
+
 from minions.prompts.minion import (
     SUPERVISOR_CONVERSATION_PROMPT,
     SUPERVISOR_FINAL_PROMPT,
@@ -16,8 +19,7 @@ from minions.prompts.minion import (
     WORKER_PRIVACY_SHIELD_PROMPT,
     REFORMAT_QUERY_PROMPT,
 )
-from minions.usage import Usage
-from minions.utils.energy_tracking import PowerMonitor, cloud_inference_energy_estimate
+
 
 def _escape_newlines_in_strings(json_str: str) -> str:
     # This regex naively matches any content inside double quotes (including escaped quotes)
@@ -423,7 +425,7 @@ class Minion:
         # Estimate energy consumption of workload done fully in cloud
         local_tokens = local_usage.completion_tokens + local_usage.prompt_tokens
         _, remote_energy_estimate, _ = cloud_inference_energy_estimate(tokens=local_tokens)
-        
+
         return {
             "final_answer": final_answer,
             "supervisor_messages": supervisor_messages,

--- a/minions/minion.py
+++ b/minions/minion.py
@@ -7,7 +7,8 @@ from datetime import datetime
 from minions.clients import OpenAIClient, TogetherClient
 
 from minions.usage import Usage
-from minions.utils.energy_tracking import PowerMonitor, cloud_inference_energy_estimate
+from minions.utils.energy_tracking import PowerMonitor
+from minions.utils.energy_tracking import cloud_inference_energy_estimate
 
 from minions.prompts.minion import (
     SUPERVISOR_CONVERSATION_PROMPT,
@@ -417,14 +418,26 @@ class Minion:
         # Stop tracking power
         monitor.stop()
 
-        final_estimates = monitor.get_final_estimates()
-        
-        # remove units from measurement (assumed to be in W)
-        local_client_energy_measurement = float(final_estimates["Measured Energy"][:-2])
+        # Local/remote input/output tokens
+        local_input_tokens = local_usage.prompt_tokens
+        local_output_tokens = local_usage.completion_tokens
+        remote_input_tokens = remote_usage.prompt_tokens
+        remote_output_tokens = remote_usage.completion_tokens
 
-        # Estimate energy consumption of workload done fully in cloud
-        local_tokens = local_usage.completion_tokens + local_usage.prompt_tokens
-        _, remote_energy_estimate, _ = cloud_inference_energy_estimate(tokens=local_tokens)
+        total_input_tokens = local_input_tokens + remote_input_tokens
+        total_output_tokens = local_output_tokens + remote_output_tokens
+
+        # Estimate remote-only energy consumption (remote processes all input/output tokens)
+        _, remote_only_energy, _ = cloud_inference_energy_estimate(
+            tokens=total_output_tokens+total_input_tokens
+        )
+
+        # Estimate minion energy consumption (including both remote and local energy consumption)
+        final_estimates = monitor.get_final_estimates()
+        minion_local_energy = float(final_estimates["Measured Energy"][:-2])
+        _, minion_remote_energy, _ = cloud_inference_energy_estimate(
+            tokens=remote_output_tokens+remote_input_tokens,
+        )
 
         return {
             "final_answer": final_answer,
@@ -433,6 +446,7 @@ class Minion:
             "remote_usage": remote_usage,
             "local_usage": local_usage,
             "log_file": log_path,
-            "remote_only_energy": remote_energy_estimate,
-            "local_client_energy": local_client_energy_measurement
+            "remote_only_energy": remote_only_energy,
+            "minion_local_energy": minion_local_energy,
+            "minion_remote_energy": minion_remote_energy
         }

--- a/minions/minions.py
+++ b/minions/minions.py
@@ -8,6 +8,7 @@ from rank_bm25 import BM25Plus
 import numpy as np
 
 from minions.usage import Usage
+from minions.utils.energy_tracking import PowerMonitor, cloud_inference_energy_estimate
 
 from minions.prompts.minions import (
     WORKER_PROMPT_TEMPLATE,
@@ -257,6 +258,10 @@ class Minions:
         Returns:
             Dict containing final_answer and conversation histories
         """
+
+        # Setup and start power monitor
+        monitor = PowerMonitor(mode="auto", interval=1.0)
+        monitor.start()
 
         self.max_rounds = max_rounds or self.max_rounds
 
@@ -732,10 +737,24 @@ class Minions:
                 f"Exhausted all rounds without finding a final answer. Returning the last synthesized response."
             )
             final_answer = "No answer found."
+        
+        # Stop tracking power
+        monitor.stop()
+
+        final_estimates = monitor.get_final_estimates()
+        
+        # remove units from measurement (assumed to be in W)
+        local_client_energy_measurement = float(final_estimates["Measured Energy"][:-2])
+
+        # Estimate energy consumption of workload done fully in cloud
+        local_tokens = local_usage.completion_tokens + local_usage.prompt_tokens
+        _, remote_energy_estimate, _ = cloud_inference_energy_estimate(tokens=local_tokens)
 
         return {
             "final_answer": final_answer,
             "meta": meta,
             "local_usage": local_usage,
             "remote_usage": remote_usage,
+            "remote_only_energy": remote_energy_estimate,
+            "local_client_energy": local_client_energy_measurement
         }

--- a/minions/utils/energy_tracking.py
+++ b/minions/utils/energy_tracking.py
@@ -327,7 +327,8 @@ def better_cloud_inference_energy_estimate(
     https://epoch.ai/gradient-updates/how-much-energy-does-chatgpt-use#appendix
     """
     if model_attr is None:
-        # approximation for GPT-4o from scaling up 
+        # approximation for GPT-4o from scaling up Mixtral 8x22b model (open-source model with known architecture)
+        # should change if better approximations exist
         model_attr = {
             "num_active_params" : 100e9, # number of active parameters in the model (used during inference)
             "hidden_dim" : 8448.42, # model dimension (size of hidden state = embedding size)
@@ -349,6 +350,7 @@ def better_cloud_inference_energy_estimate(
         (https://www.microsoft.com/en-us/research/uploads/prod/2024/03/GPU_Power_ASPLOS_24.pdf)
         """
 
+        # estimates for H100 GPU
         gpu_attr = {
             "peak_flops" : 9.89e14,
             "gpu_prefill_util" : 0.5,

--- a/minions/utils/energy_tracking.py
+++ b/minions/utils/energy_tracking.py
@@ -335,7 +335,7 @@ def better_cloud_inference_energy_estimate(
             "num_attn_heads" : 57.0, # number of attention heads
             "num_layers" : 77.0, # number of transformer blocks in model
             "flops_per_tkn_factor" : 2,
-            "flops_per_tkn_factor_self_attn" : 4
+            "flops_per_tkn_factor_attn" : 4
         }
     
     if gpu_attr is None:
@@ -355,7 +355,7 @@ def better_cloud_inference_energy_estimate(
     prefill_flops = input_tokens * model_attr["flops_per_tkn_factor"] * model_attr["num_active_params"]
     prefill_flops += (
         (input_tokens ** 2)
-        * model_attr["flops_per_tkn_factor_self_attn"] * model_attr["num_attn_heads"]
+        * model_attr["flops_per_tkn_factor_attn"] * model_attr["num_attn_heads"]
         * model_attr["attn_head_dim"] * model_attr["num_layers"]
     )
 
@@ -370,7 +370,7 @@ def better_cloud_inference_energy_estimate(
     decoding_flops = output_tokens * model_attr["flops_per_tkn_factor"] * model_attr["num_active_params"]
     decoding_flops += (
         (decoding_mean_tokens * output_tokens)
-        * model_attr["flops_per_tkn_factor_self_attn"] * model_attr["num_attn_heads"]
+        * model_attr["flops_per_tkn_factor_attn"] * model_attr["num_attn_heads"]
         * model_attr["attn_head_dim"] * model_attr["num_layers"]
     )
 

--- a/minions/utils/energy_tracking.py
+++ b/minions/utils/energy_tracking.py
@@ -158,7 +158,6 @@ class PowerMonitor:
                         measurement = {"error": "RAPL energy cycled"}
                     else:
                         power = delta / (1_000_000 * measurement_time)
-                        print(power)
                         measurement = {"Power": power}
                 except Exception as e:
                     measurement = {"error": str(e)}

--- a/minions/utils/energy_tracking.py
+++ b/minions/utils/energy_tracking.py
@@ -339,6 +339,16 @@ def better_cloud_inference_energy_estimate(
         }
     
     if gpu_attr is None:
+        """
+        GPU utilization higher during prefill stage because of parallel processing of inputs
+        during decoding stage, new output tokens are generated sequentially with the auto-regressive function
+        (https://arxiv.org/pdf/2410.18038v1)
+
+        power utilization is very high during prefill stage (compute-heavy)
+        differs from less compute-intense decoding stage
+        (https://www.microsoft.com/en-us/research/uploads/prod/2024/03/GPU_Power_ASPLOS_24.pdf)
+        """
+
         gpu_attr = {
             "peak_flops" : 9.89e14,
             "gpu_prefill_util" : 0.5,

--- a/tests/energy-estimate-test.py
+++ b/tests/energy-estimate-test.py
@@ -1,0 +1,23 @@
+from minions.utils.energy_tracking import cloud_inference_energy_estimate, better_cloud_inference_energy_estimate
+
+"""
+test to compare different cloud inference energy estimates as 
+number of input and output tokens are scaled
+"""
+
+# scaling number of input tokens
+input_tokens = 100
+output_tokens = 500
+
+print(f"Fixed output tokens: {output_tokens}")
+for i in range(5):
+    _, orig_est, _ = cloud_inference_energy_estimate(tokens=input_tokens+output_tokens)
+    new_est = better_cloud_inference_energy_estimate(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens
+    )
+    new_est = new_est["total_energy_joules"]
+
+    print(f"Input tokens: {input_tokens}, Original estimate: {orig_est:.2f}, New estimate: {new_est:.2f}")
+
+    input_tokens *= 10

--- a/tests/minion-base-example.py
+++ b/tests/minion-base-example.py
@@ -20,7 +20,7 @@ Recent laboratory results show that his LDL cholesterol level is elevated at 170
 """
 
 context_summary = """
-John Doe, a 60-year-old male with hypertension, has elevated blood pressure (160/100 mmHg), occasional exertional chest discomfort, and high LDL cholesterol (170 mg/dL), while other metabolic indicators are normal.
+The context provides lab results for a patient John Doe
 """
 
 task = "Based on the patient's blood pressure and LDL cholesterol readings in the context, evaluate whether these factors together suggest an increased risk for cardiovascular complications."

--- a/tests/minion-base-example.py
+++ b/tests/minion-base-example.py
@@ -3,7 +3,7 @@ from minions.clients.openai import OpenAIClient
 from minions.minion import Minion
 
 local_client = OllamaClient(
-        model_name="llama3.2",
+        model_name="llama3.2:3b",
     )
 
 remote_client = OpenAIClient(
@@ -17,6 +17,10 @@ minion = Minion(local_client, remote_client)
 context = """
 Patient John Doe is a 60-year-old male with a history of hypertension. In his latest checkup, his blood pressure was recorded at 160/100 mmHg, and he reported occasional chest discomfort during physical activity.
 Recent laboratory results show that his LDL cholesterol level is elevated at 170 mg/dL, while his HDL remains within the normal range at 45 mg/dL. Other metabolic indicators, including fasting glucose and renal function, are unremarkable.
+"""
+
+context_summary = """
+John Doe, a 60-year-old male with hypertension, has elevated blood pressure (160/100 mmHg), occasional exertional chest discomfort, and high LDL cholesterol (170 mg/dL), while other metabolic indicators are normal.
 """
 
 task = "Based on the patient's blood pressure and LDL cholesterol readings in the context, evaluate whether these factors together suggest an increased risk for cardiovascular complications."

--- a/tests/minion-base-example.py
+++ b/tests/minion-base-example.py
@@ -1,0 +1,33 @@
+from minions.clients.ollama import OllamaClient
+from minions.clients.openai import OpenAIClient
+from minions.minion import Minion
+
+local_client = OllamaClient(
+        model_name="llama3.2",
+    )
+
+remote_client = OpenAIClient(
+        model_name="gpt-4o",
+    )
+
+# Instantiate the Minion object with both clients
+minion = Minion(local_client, remote_client)
+
+
+context = """
+Patient John Doe is a 60-year-old male with a history of hypertension. In his latest checkup, his blood pressure was recorded at 160/100 mmHg, and he reported occasional chest discomfort during physical activity.
+Recent laboratory results show that his LDL cholesterol level is elevated at 170 mg/dL, while his HDL remains within the normal range at 45 mg/dL. Other metabolic indicators, including fasting glucose and renal function, are unremarkable.
+"""
+
+task = "Based on the patient's blood pressure and LDL cholesterol readings in the context, evaluate whether these factors together suggest an increased risk for cardiovascular complications."
+
+# Execute the minion protocol for up to two communication rounds
+output = minion(
+    task=task,
+    context=[context],
+    max_rounds=2
+)
+
+for x in output.keys():
+    print(f"\n--- {x} ---")
+    print(output[x])

--- a/tests/minion-energy-tracking-basic.py
+++ b/tests/minion-energy-tracking-basic.py
@@ -1,0 +1,53 @@
+from minions.clients.ollama import OllamaClient
+from minions.clients.openai import OpenAIClient
+from minions.minion import Minion
+
+from minions.utils.energy_tracking import PowerMonitor, cloud_inference_energy_estimate
+
+# Setup power monitor
+monitor = PowerMonitor(mode="auto", interval=1.0)
+
+local_client = OllamaClient(
+        model_name="llama3.2",
+    )
+
+remote_client = OpenAIClient(
+        model_name="gpt-4o",
+    )
+
+# Instantiate the Minion object with both clients
+minion = Minion(local_client, remote_client)
+
+
+context = """
+Patient John Doe is a 60-year-old male with a history of hypertension. In his latest checkup, his blood pressure was recorded at 160/100 mmHg, and he reported occasional chest discomfort during physical activity.
+Recent laboratory results show that his LDL cholesterol level is elevated at 170 mg/dL, while his HDL remains within the normal range at 45 mg/dL. Other metabolic indicators, including fasting glucose and renal function, are unremarkable.
+"""
+
+task = "Based on the patient's blood pressure and LDL cholesterol readings in the context, evaluate whether these factors together suggest an increased risk for cardiovascular complications."
+
+# Execute the minion protocol for up to two communication rounds
+monitor.start()
+output = minion(
+    task=task,
+    context=[context],
+    max_rounds=2
+)
+monitor.stop()
+
+final_estimates = monitor.get_final_estimates()
+
+# Display energy consumption
+print("\nMeasured Energy and Power Metrics --- (Minions) Local Client")
+for key, value in final_estimates.items():
+    print(f"{key}: {value}")
+
+# Estimate energy consumption of workload done fully in cloud
+local_tokens = output["local_usage"].completion_tokens + output["local_usage"].prompt_tokens
+power_estimate, energy_estimate, _ = cloud_inference_energy_estimate(tokens=local_tokens)
+
+print(f"(Baseline) Remote Only Energy Estimate: {energy_estimate} J")
+
+for x in output.keys():
+    print(f"\n--- {x} ---")
+    print(output[x])

--- a/tests/minions-base-example.py
+++ b/tests/minions-base-example.py
@@ -1,0 +1,43 @@
+from minions.clients.ollama import OllamaClient
+from minions.clients.openai import OpenAIClient
+from minions.minions import Minions
+from pydantic import BaseModel
+
+class StructuredLocalOutput(BaseModel):
+    explanation: str
+    citation: str | None
+    answer: str | None
+
+local_client = OllamaClient(
+        model_name="llama3.2",
+        temperature=0.0,
+        structured_output_schema=StructuredLocalOutput
+)
+
+remote_client = OpenAIClient(
+        model_name="gpt-4o",
+)
+
+
+# Instantiate the Minion object with both clients
+minion = Minions(local_client, remote_client)
+
+
+context = """
+Patient John Doe is a 60-year-old male with a history of hypertension. In his latest checkup, his blood pressure was recorded at 160/100 mmHg, and he reported occasional chest discomfort during physical activity.
+Recent laboratory results show that his LDL cholesterol level is elevated at 170 mg/dL, while his HDL remains within the normal range at 45 mg/dL. Other metabolic indicators, including fasting glucose and renal function, are unremarkable.
+"""
+
+task = "Based on the patient's blood pressure and LDL cholesterol readings in the context, evaluate whether these factors together suggest an increased risk for cardiovascular complications."
+
+# Execute the minion protocol for up to two communication rounds
+output = minion(
+    task=task,
+    doc_metadata="Medical Report",
+    context=[context],
+    max_rounds=2
+)
+
+for x in output.keys():
+    print(f"\n--- {x} ---")
+    print(output[x])

--- a/tests/minions-base-example.py
+++ b/tests/minions-base-example.py
@@ -9,7 +9,7 @@ class StructuredLocalOutput(BaseModel):
     answer: str | None
 
 local_client = OllamaClient(
-        model_name="llama3.2",
+        model_name="llama3.2:3b",
         temperature=0.0,
         structured_output_schema=StructuredLocalOutput
 )

--- a/tests/power-test.py
+++ b/tests/power-test.py
@@ -1,0 +1,24 @@
+import time
+from datetime import datetime
+
+def read_energy():
+    """Read energy consumption from RAPL in microjoules (µJ)."""
+    with open("/sys/class/powercap/intel-rapl:0/energy_uj", "r") as f:
+        return int(f.read().strip())
+
+def get_power_usage(interval=0.5):
+    """Calculate power consumption in watts over a given time interval."""
+    energy_start = read_energy()
+    time.sleep(interval)
+    energy_end = read_energy()
+    
+    power_watts = (energy_end - energy_start) / (interval * 1_000_000)  # Convert µJ to W
+    return power_watts
+
+if __name__ == "__main__":
+    for i in range(100):
+        power = get_power_usage()
+        # Get the current time
+        current_time = datetime.now().strftime("%H:%M:%S")
+        print(f"{current_time}, power: {power:.6f} W")
+        time.sleep(0.5)

--- a/tests/power-test.py
+++ b/tests/power-test.py
@@ -2,12 +2,12 @@ import time
 from datetime import datetime
 
 def read_energy():
-    """Read energy consumption from RAPL in microjoules (µJ)."""
+    # Read energy consumption from RAPL in microjoules (µJ).
     with open("/sys/class/powercap/intel-rapl:0/energy_uj", "r") as f:
         return int(f.read().strip())
 
 def get_power_usage(interval=0.5):
-    """Calculate power consumption in watts over a given time interval."""
+    # Calculate power consumption in watts over a given time interval.
     energy_start = read_energy()
     time.sleep(interval)
     energy_end = read_energy()


### PR DESCRIPTION
There were a few changes I added, mostly in updating the current energy estimates for remote model inference as well as integrating this energy tracking with the minions app UI. The following list describes the features and tests I added:

Local energy consumption tracking for Linux
- Currently, power monitoring is implemented for Mac and NVIDIA devices, so I integrated power tracking for Linux devices using RAPL (which my current device has) into the functions of the PowerMonitor class (energy_tracking.py)
- The measurements received match up with the measurements from other Linux tools for measuring device power consumption (e.g. powerstat)

Integration with Minion(s) protocols
- Added power monitoring to both minion.py and minions.py
- Used power measurements to provide estimate for local energy consumption, and combined these values with estimates for remote energy consumption, which were then returned from the respective __call__ functions

Integration with app UI
- Added visualization of local/remote energy consumption both when using the Minion(s) protocol and when estimating for remote-only inference
- Also displays total amount of energy used in each case, as well as total energy savings

Added more detailed estimates for cloud inference energy consumption
- Create a function (better_cloud_inference_energy_estimate in energy_tracking.py) which differentiates between the prefill and decoding stages of inference
- Also updates some of the pre-defined constants (like power and GPU utilization) to match up with recent papers and tests done with LLM inference on GPUs
- Added quadratic dependence of the FLOPs required for inference on the number of input/output tokens, as seen in the attention mechanism for transformers (this has more of an impact for the larger input context lengths, which is Minion(s) primary focus)