### PR TITLE
Added embedding based retrieval

### DIFF
--- a/minions/minions.py
+++ b/minions/minions.py
@@ -4,8 +4,6 @@ import re
 import json
 from pydantic import BaseModel, field_validator, Field
 from inspect import getsource
-from rank_bm25 import BM25Plus
-import numpy as np
 
 from minions.usage import Usage
 
@@ -28,7 +26,11 @@ from minions.prompts.minions import (
     REMOTE_SYNTHESIS_COT,
     REMOTE_SYNTHESIS_JSON,
     REMOTE_SYNTHESIS_FINAL,
+    BM25_INSTRUCTIONS,
+    EMBEDDING_INSTRUCTIONS
 )
+
+from minions.utils.retrievers import *
 
 
 def chunk_by_section(
@@ -41,33 +43,6 @@ def chunk_by_section(
         sections.append(doc[start:end])
         start += max_chunk_size - overlap
     return sections
-
-
-def retrieve_top_k_chunks(
-    keywords: List[str], chunks: List[str], weights: Dict[str, float], k: int = 10
-) -> List[str]:
-    """
-    Returns the k most relevant chunks based on weighted BM25+ ranking.
-
-    Example:
-        Task: "What was Mrs. Anderson's tumor marker levels in 2021"
-        queries = {"Mrs. Anderson": 5.0, "tumor marker": 3.0, "2021": 1.5, "Anderson": 1.0}
-        relevant_chunks = retrieve_top_k_chunks(queries.keys(), chunks, k=10, weights=queries)
-    """
-    weights = {keyword: weights.get(keyword, 1.0) for keyword in keywords}
-    bm25_retriever = BM25Plus(chunks)
-
-    final_scores = np.zeros(len(chunks))
-    for keyword, weight in weights.items():
-        scores = bm25_retriever.get_scores(keyword)
-        final_scores += weight * scores
-
-    top_k_indices = sorted(
-        range(len(final_scores)), key=lambda i: final_scores[i], reverse=True
-    )[:k]
-    top_k_indices = sorted(top_k_indices)
-    relevant_chunks = [chunks[i] for i in top_k_indices]
-    return relevant_chunks
 
 
 class JobManifest(BaseModel):
@@ -244,7 +219,7 @@ class Minions:
         num_tasks_per_round=3,
         num_samples_per_task=1,
         mcp_tools_info=None,
-        use_bm25=False,
+        use_retrieval=None,
     ):
         """Run the minions protocol to answer a task using local and remote models.
 
@@ -253,12 +228,25 @@ class Minions:
             doc_metadata: Type of document being analyzed
             context: List of context strings
             max_rounds: Override default max_rounds if provided
+            retrieval: Retrieval strategy to use. Options:
+                - None: Don't use retrieval
+                - "bm25": Use BM25 keyword-based retrieval
+                - "embedding": Use embedding-based retrieval
+
 
         Returns:
             Dict containing final_answer and conversation histories
         """
 
         self.max_rounds = max_rounds or self.max_rounds
+
+        retriever = None
+
+        if use_retrieval:
+            if use_retrieval == "bm25":
+                retriever = bm25_retrieve_top_k_chunks
+            elif use_retrieval == "embedding":
+                retriever = embedding_retrieve_top_k_chunks
 
         # Initialize usage tracking
         remote_usage = Usage()
@@ -306,6 +294,20 @@ class Minions:
                 # compute characters in context
                 total_chars = sum(len(doc) for doc in context)
 
+            retrieval_source = ""
+            retrieval_instructions = ""
+
+            if use_retrieval:
+                retrieval_source = getsource(retriever).split(
+                    "    weights = "
+                )[0]
+                
+                retrieval_instructions = (
+                    BM25_INSTRUCTIONS if use_retrieval == "bm25" 
+                    else EMBEDDING_INSTRUCTIONS if use_retrieval == "embedding"
+                    else ""
+                )
+
             decompose_message_kwargs = dict(
                 num_samples=self.num_samples,
                 ADVANCED_STEPS_INSTRUCTIONS="",
@@ -317,9 +319,8 @@ class Minions:
                 chunking_source="\n\n".join(
                     [getsource(chunk_by_section).split("    sections = ")[0]]
                 ),
-                retrieval_source=getsource(retrieve_top_k_chunks).split(
-                    "    weights = "
-                )[0],
+                retrieval_source=retrieval_source,
+                retrieval_instructions=retrieval_instructions,
                 num_tasks_per_round=num_tasks_per_round,
                 num_samples_per_task=num_samples_per_task,
                 total_chars=total_chars,
@@ -327,7 +328,7 @@ class Minions:
 
             decompose_prompt = (
                 self.decompose_task_prompt
-                if not use_bm25
+                if not use_retrieval
                 else self.decompose_retrieval_task_prompt
             )
             # create the decompose prompt -- if in later rounds, use a shorter version
@@ -345,7 +346,7 @@ class Minions:
             else:
                 decompose_prompt_abbrev = (
                     self.decompose_task_prompt_abbreviated
-                    if not use_bm25
+                    if not use_retrieval
                     else self.decompose_retrieval_task_prompt_abbreviated
                 )
                 if feedback is not None:
@@ -403,11 +404,13 @@ class Minions:
                 starting_globals = {
                     **USEFUL_IMPORTS,
                     "chunk_by_section": chunk_by_section,
-                    "retrieve_top_k_chunks": retrieve_top_k_chunks,
                     "JobManifest": JobManifest,
                     "JobOutput": JobOutput,
                     "Job": Job,
                 }
+
+                if use_retrieval:
+                    starting_globals[f"{use_retrieval}_retrieve_top_k_chunks"] = retriever
 
                 fn_kwargs = {
                     "context": context,

--- a/minions/utils/retrievers.py
+++ b/minions/utils/retrievers.py
@@ -1,0 +1,101 @@
+import torch
+from typing import List, Dict
+from rank_bm25 import BM25Plus
+from abc import ABC, abstractmethod
+import numpy as np
+from sentence_transformers import SentenceTransformer
+import faiss
+
+    
+def bm25_retrieve_top_k_chunks(
+    keywords: List[str], chunks: List[str] = None, weights: Dict[str, float] = None, k: int = 10
+) -> List[str]:
+    """
+    Retrieves top k chunks using BM25 with weighted keywords.
+    """
+    
+    weights = {keyword: weights.get(keyword, 1.0) for keyword in keywords}
+    bm25_retriever = BM25Plus(chunks)
+
+    final_scores = np.zeros(len(chunks))
+    for keyword, weight in weights.items():
+        scores = bm25_retriever.get_scores(keyword)
+        final_scores += weight * scores
+
+    top_k_indices = sorted(
+        range(len(final_scores)), key=lambda i: final_scores[i], reverse=True
+    )[:k]
+    top_k_indices = sorted(top_k_indices)
+    relevant_chunks = [chunks[i] for i in top_k_indices]
+
+    return relevant_chunks
+    
+
+class BaseEmbeddingModel(ABC):
+    """
+    Abstract base class defining interface for embedding models.
+    """
+    @abstractmethod
+    def get_model(self, **kwargs):
+        """Get or initialize the embedding model."""
+        pass
+        
+    @abstractmethod
+    def encode(self, texts, **kwargs) -> np.ndarray:
+        """Encode texts to create embeddings."""
+        pass
+
+class EmbeddingModel(BaseEmbeddingModel):
+    """
+    Singleton implementation of embedding model using SentenceTransformer.
+    """
+    _instance = None
+    _model = None
+    _default_model_name = 'intfloat/multilingual-e5-large-instruct'
+    
+    def __new__(cls, model_name=None):
+        if cls._instance is None:
+            cls._instance = super(EmbeddingModel, cls).__new__(cls)
+            model_name = model_name or cls._default_model_name
+            cls._model = SentenceTransformer(model_name)
+            if torch.cuda.is_available():
+                cls._model = cls._model.to(torch.device("cuda"))
+        return cls._instance
+    
+    @classmethod
+    def get_model(cls, model_name=None):
+        if cls._instance is None:
+            cls._instance = cls(model_name)
+        return cls._model
+    
+    @classmethod
+    def encode(cls, texts, model_name=None) -> np.ndarray:
+        model = cls.get_model(model_name)
+        return model.encode(texts).astype('float32')
+
+
+def embedding_retrieve_top_k_chunks(
+    queries: List[str], chunks: List[str] = None, k: int = 10
+) -> List[str]:
+    """
+    Retrieves top k chunks using dense vector embeddings and FAISS similarity search
+    """
+    
+    chunk_embeddings = EmbeddingModel.encode(chunks).astype('float32')
+    
+    embedding_dim = chunk_embeddings.shape[1]
+    index = faiss.IndexFlatIP(embedding_dim)
+    index.add(chunk_embeddings)
+    
+    aggregated_scores = np.zeros(len(chunks))
+    
+    for query in queries:
+        query_embedding = EmbeddingModel.encode([query]).astype('float32')
+        cur_scores, cur_indices = index.search(query_embedding, k)
+        np.add.at(aggregated_scores, cur_indices[0], cur_scores[0])
+    
+    top_k_indices = np.argsort(aggregated_scores)[::-1][:k]
+    
+    relevant_chunks = [chunks[i] for i in top_k_indices]
+
+    return relevant_chunks

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ setup(
         "rank_bm25",  # for smart retrieval
         "PyMuPDF",  # for PDF handling
         "firecrawl-py",  # for scraping urls
+        "faiss-cpu", # for embedding search
+        "sentence-transformers", # for pretrained embedding models
+        "torch" # for running embedding models on CUDA
     ],
     extras_require={
         "mlx": ["mlx-lm"],


### PR DESCRIPTION
## Overview
This PR adds embedding-based retrieval to `minions/minions.py` alongside the existing BM25 retrieval.

## Implementation Details
- **Embedding Model**: `intfloat/multilingual-e5-large-instruct` (560M parameters)
- **Test Environment**: Macbook Pro with M3 Max chip and NVIDIA A100
- **Models Used**: Remote - `GPT-4o`, Local - `Llama3.2-3B`
- **max_rounds**: `5`

## Changes
- Made `minions/minions.py` retrieval method agnostic
- Added embedding-based retrieval implementation to `utils/retrievers.py`
- Decomposed embedding and BM25 based prompts in  `prompts/minions.py`

## Evaluation Results
Experiments were conducted on 20 random questions from the NarrativeQA dataset to compare the performance of BM25 and embedding-based retrieval.

### 1. Retrieval Speed & Scalability
<img width="600" alt="Screenshot 2025-03-25 at 8 31 10 AM" src="https://github.com/user-attachments/assets/6336d45d-5862-4626-9ab3-ffd6d40544f4" />

The log-scale comparison reveals:
- **BM25** (green): Fastest option (0.001s-0.03s) with excellent scalability
- **Embeddings GPU** (purple): Moderate performance (0.1s-5s) with reasonable scalability
- **Embeddings CPU** (orange): Slowest performance (1s-20s) with poor scalability (steepest slope)

### 2. Token Efficiency
| Metric | BM25 | Embedding |
|--------|------|-----------|
| Remote Completion Tokens | 54,361 | **31,918** |
| Remote Prompt Tokens | 208,395 | **137,972** |
| Local Completion Tokens | 5,266 | **3,595** |
| Local Prompt Tokens | 450,610 | **263,919** |
| Retrieval Instances | 53 | **32** |
| Total Time | **26m 59s** | 31m 33s |

**Key Finding**: The embedding-based approach betters captures semantic relationships than BM25, so this leads to retrieving more relevant chunks on earlier attempts. With more relevant context chunks, fewer worker models need to be deployed, which results in reduced token usage This also led to fewer retrieval operations than BM25 (32 vs 53) on the same set of questions.

### 3. Answer Quality
| Metric | BM25 | Embedding |
|--------|------|-----------|
| BLEU-1 | 0.146 | **0.166** |
| BLEU-4 | **0.026** | 0.0 |
| METEOR | 0.237 | **0.302** |
| ROUGE-L | 0.213 | **0.271** |

**Key Finding**: Embedding-based retrieval performs significantly better in downstream QA tasks (METEOR and ROUGE-L).

## Usage Example
```python
protocol = Minions(local_client=local_client, remote_client=remote_client)
output = protocol(
        task=task,
        doc_metadata=doc_metadata,
        context=[context],
        max_rounds=5,
        use_retrieval="embedding" # Options: "bm25", "embedding", or None
)
```

## Next Steps
- Implement batched processing for embedding-based retrieval to improve scalability
- Explore smarter text chunking strategies
- Explore hybrid retrieval approaches