### PR TITLE
Add the MCP to Minion. (MCP = Model Context Protocol)

### DIFF
--- a/minions/prompts/minion_mcp.py
+++ b/minions/prompts/minion_mcp.py
@@ -1,21 +1,21 @@
-SUPERVISOR_INITIAL_PROMPT_OLD = """\
-We need to perform the following task.
-
-### Task
-{task}
-
-### Instructions
-You will not have direct access to the context, but can chat with a small language model which has read the entire thing.
-
-Feel free to think step-by-step, but eventually you must provide an output in the format below:
-
-<think step by step here>
-```json
-{{
-    "message": "<your message to the small language model. If you are asking model to do a task, make sure it is a single task!>"
-}}
-```
-"""
+# SUPERVISOR_INITIAL_PROMPT_OLD = """\
+# We need to perform the following task.
+#
+# ### Task
+# {task}
+#
+# ### Instructions
+# You will not have direct access to the context, but can chat with a small language model which has read the entire thing.
+#
+# Feel free to think step-by-step, but eventually you must provide an output in the format below:
+#
+# <think step by step here>
+# ```json
+# {{
+#     "message": "<your message to the small language model. If you are asking model to do a task, make sure it is a single task!>"
+# }}
+# ```
+# """
 
 WORKER_PRIVACY_SHIELD_PROMPT = """\
 You are a helpful assistant that is very mindful of user privacy. You are communicating with a powerful large language model that you are sharing information with. Revise the following text to preserve user privacy. We have already extracted the PII from the original document. Remove any PII from the text. Provide your output without any preamble. 
@@ -39,36 +39,36 @@ You are a helpful assistant that is very mindful of user privacy. You are commun
 
 ### Query without PII (remove the PII from the query, and rephrase the query if necessary):"""
 
-SUPERVISOR_CONVERSATION_PROMPT_OLD = """
-Here is the response from the small language model:
-
-### Response
-{response}
-
-
-### Instructions
-Analyze the response and think-step-by-step to determine if you have enough information to answer the question.
-
-If you have enough information or if the task is complete provide a final answer in the format below.
-
-<think step by step here>
-```json
-{{
-    "decision": "provide_final_answer", 
-    "answer": "<your answer>"
-}}
-```
-
-Otherwise, if the task is not complete, request the small language model to do additional work, by outputting the following:
-
-<think step by step here>
-```json
-{{
-    "decision": "request_additional_info",
-    "message": "<your message to the small language model>"
-}}
-```
-"""
+# SUPERVISOR_CONVERSATION_PROMPT_OLD = """
+# Here is the response from the small language model:
+#
+# ### Response
+# {response}
+#
+#
+# ### Instructions
+# Analyze the response and think-step-by-step to determine if you have enough information to answer the question.
+#
+# If you have enough information or if the task is complete provide a final answer in the format below.
+#
+# <think step by step here>
+# ```json
+# {{
+#     "decision": "provide_final_answer",
+#     "answer": "<your answer>"
+# }}
+# ```
+#
+# Otherwise, if the task is not complete, request the small language model to do additional work, by outputting the following:
+#
+# <think step by step here>
+# ```json
+# {{
+#     "decision": "request_additional_info",
+#     "message": "<your message to the small language model>"
+# }}
+# ```
+# """
 
 SUPERVISOR_FINAL_PROMPT_OLD = """\
 Here is the response from the small language model:
@@ -98,11 +98,13 @@ Read the context below and prepare to answer questions from an expert user.
 ### Context
 {context}
 
+Further context will be provided if the expert user uses MCP tools.
+
 ### Question
 {task}
 """
 
-SUPERVISOR_INITIAL_PROMPT = """\
+SUPERVISOR_INITIAL_PROMPT_MCP = """\
 We need to perform the following task.
 
 ### Task
@@ -110,44 +112,53 @@ We need to perform the following task.
 
 ### Instructions
 You will not have direct access to the context, but can chat with a small language model which has read the entire thing.
+If you think the small language model may need more context, you can also specify an MCP tool call, whose output will
+be given to the small language model just prior to your task.
+
+### MCP Tools Info
+{mcp_tools_info}
+
+Important: if you use an MCP tool, make sure you tell the small model exactly what you want it do with the output.
 
 Feel free to think step-by-step, but eventually you must provide an output in the format below:
 
 ```json
 {{
+    "mcp_tool_call": null,  # or, a tool call formatted in JSON as per its usage
     "message": "<your message to the small language model. If you are asking model to do a task, make sure it is a single task!>"
 }}
 ```
 """
 
-SUPERVISOR_CONVERSATION_PROMPT = """
-Here is the response from the small language model:
-
-### Response
-{response}
-
-
-### Instructions
-Analyze the response and think-step-by-step to determine if you have enough information to answer the question.
-
-If you have enough information or if the task is complete provide a final answer in the format below.
-
-```json
-{{
-    "decision": "provide_final_answer", 
-    "answer": "<your answer>"
-}}
-```
-
-Otherwise, if the task is not complete, request the small language model to do additional work, by outputting the following:
-
-```json
-{{
-    "decision": "request_additional_info",
-    "message": "<your message to the small language model>"
-}}
-```
-"""
+# SUPERVISOR_CONVERSATION_PROMPT_MCP = """
+# Here is the response from the small language model:
+#
+# ### Response
+# {response}
+#
+#
+# ### Instructions
+# Analyze the response and think-step-by-step to determine if you have enough information to answer the question.
+#
+# If you have enough information or if the task is complete provide a final answer in the format below.
+#
+# ```json
+# {{
+#     "decision": "provide_final_answer",
+#     "answer": "<your answer>"
+# }}
+# ```
+#
+# Otherwise, if the task is not complete, request the small language model to do additional work, by outputting the following:
+#
+# ```json
+# {{
+#     "decision": "request_additional_info",
+#     "mcp_tool_call": null,  # or, a tool call formatted in JSON as per its usage
+#     "message": "<your message to the small language model>"
+# }}
+# ```
+# """
 
 SUPERVISOR_FINAL_PROMPT = """\
 Here is the response from the small language model:
@@ -187,7 +198,7 @@ Think about:
 
 """
 
-REMOTE_SYNTHESIS_FINAL = """\
+REMOTE_SYNTHESIS_FINAL_MCP = """\
 Here is the response after step-by-step thinking.
 
 ### Response
@@ -208,6 +219,7 @@ Otherwise, if the task is not complete, request the small language model to do a
 ```json
 {{
     "decision": "request_additional_info",
+    "mcp_tool_call": null,  # or, a tool call formatted in JSON as per its usage
     "message": "<your message to the small language model>"
 }}
 ```

--- a/minions/prompts/minion_mcp.py
+++ b/minions/prompts/minion_mcp.py
@@ -1,104 +1,14 @@
-# SUPERVISOR_INITIAL_PROMPT_OLD = """\
-# We need to perform the following task.
-#
-# ### Task
-# {task}
-#
-# ### Instructions
-# You will not have direct access to the context, but can chat with a small language model which has read the entire thing.
-#
-# Feel free to think step-by-step, but eventually you must provide an output in the format below:
-#
-# <think step by step here>
-# ```json
-# {{
-#     "message": "<your message to the small language model. If you are asking model to do a task, make sure it is a single task!>"
-# }}
-# ```
-# """
+# These prompts are supplementary to those in minion.py, used for when Minion() access to MCP tools
 
-WORKER_PRIVACY_SHIELD_PROMPT = """\
-You are a helpful assistant that is very mindful of user privacy. You are communicating with a powerful large language model that you are sharing information with. Revise the following text to preserve user privacy. We have already extracted the PII from the original document. Remove any PII from the text. Provide your output without any preamble. 
-
-### PII Extracted:
-{pii_extracted}
-
-### Text to revise:
-{output}
-
-### Revised Text:"""
-
-REFORMAT_QUERY_PROMPT = """\
-You are a helpful assistant that is very mindful of user privacy. You are communicating with a powerful large language model that you are sharing information with. Revise the following query to remove any PII. Provide your output without any preamble. DO NOT ANSWER THE QUERY, JUST REMOVE THE PII.
-
-### Extracted PII:
-{pii_extracted}
-
-### Query:
-{query}
-
-### Query without PII (remove the PII from the query, and rephrase the query if necessary):"""
-
-# SUPERVISOR_CONVERSATION_PROMPT_OLD = """
-# Here is the response from the small language model:
-#
-# ### Response
-# {response}
-#
-#
-# ### Instructions
-# Analyze the response and think-step-by-step to determine if you have enough information to answer the question.
-#
-# If you have enough information or if the task is complete provide a final answer in the format below.
-#
-# <think step by step here>
-# ```json
-# {{
-#     "decision": "provide_final_answer",
-#     "answer": "<your answer>"
-# }}
-# ```
-#
-# Otherwise, if the task is not complete, request the small language model to do additional work, by outputting the following:
-#
-# <think step by step here>
-# ```json
-# {{
-#     "decision": "request_additional_info",
-#     "message": "<your message to the small language model>"
-# }}
-# ```
-# """
-
-SUPERVISOR_FINAL_PROMPT_OLD = """\
-Here is the response from the small language model:
-
-### Response
-{response}
-
-
-### Instructions
-This is the final round, you cannot request additional information.
-Analyze the response and think-step-by-step and answer the question.
-
-<think step by step here>
-```json
-{{
-    "decision": "provide_final_answer",
-    "answer": "<your answer>"
-}}
-```
-DO NOT request additional information. Simply provide a final answer.
-"""
-
-WORKER_SYSTEM_PROMPT = """\
+WORKER_SYSTEM_PROMPT_MCP = """\
 You will help a user perform the following task.
 
-Read the context below and prepare to answer questions from an expert user. 
+Read the context below and prepare to answer questions from an expert user. Further context will be provided if the 
+expert user invokes MCP tools. The expert user won't be able to see the MCP tool outputs, so please convey everything 
+necessary to answer the expert user's questions.
 ### Context
 {context}
 
-Further context will be provided if the expert user uses MCP tools.
 
 ### Question
 {task}
@@ -113,89 +23,24 @@ We need to perform the following task.
 ### Instructions
 You will not have direct access to the context, but can chat with a small language model which has read the entire thing.
 If you think the small language model may need more context, you can also specify an MCP tool call, whose output will
-be given to the small language model just prior to your task.
+be given to the small language model just prior to your task. However, the small language model can't invoke the MCP
+tools on its own. Also, you won't see the output, so make sure your message to the small model is clear about
+exactly what information you want the small model to convey to you from the tool output.
 
 ### MCP Tools Info
 {mcp_tools_info}
-
-Important: if you use an MCP tool, make sure you tell the small model exactly what you want it do with the output.
 
 Feel free to think step-by-step, but eventually you must provide an output in the format below:
 
 ```json
 {{
-    "mcp_tool_call": null,  # or, a tool call formatted in JSON as per its usage
+    "mcp_tool_calls": [],  # a list of tool calls, formatted in JSON as per their usage (can be an empty list)
     "message": "<your message to the small language model. If you are asking model to do a task, make sure it is a single task!>"
 }}
 ```
-"""
 
-# SUPERVISOR_CONVERSATION_PROMPT_MCP = """
-# Here is the response from the small language model:
-#
-# ### Response
-# {response}
-#
-#
-# ### Instructions
-# Analyze the response and think-step-by-step to determine if you have enough information to answer the question.
-#
-# If you have enough information or if the task is complete provide a final answer in the format below.
-#
-# ```json
-# {{
-#     "decision": "provide_final_answer",
-#     "answer": "<your answer>"
-# }}
-# ```
-#
-# Otherwise, if the task is not complete, request the small language model to do additional work, by outputting the following:
-#
-# ```json
-# {{
-#     "decision": "request_additional_info",
-#     "mcp_tool_call": null,  # or, a tool call formatted in JSON as per its usage
-#     "message": "<your message to the small language model>"
-# }}
-# ```
-# """
-
-SUPERVISOR_FINAL_PROMPT = """\
-Here is the response from the small language model:
-
-### Response
-{response}
-
-
-### Instructions
-This is the final round, you cannot request additional information.
-Analyze the response and think-step-by-step and answer the question.
-
-```json
-{{
-    "decision": "provide_final_answer",
-    "answer": "<your answer>"
-}}
-```
-DO NOT request additional information. Simply provide a final answer.
-"""
-
-REMOTE_SYNTHESIS_COT = """
-Here is the response from the small language model:
-
-### Response
-{response}
-
-
-### Instructions
-Analyze the response and think-step-by-step to determine if you have enough information to answer the question.
-
-Think about:
-1. What information we have gathered
-2. Whether it is sufficient to answer the question
-3. If not sufficient, what specific information is missing
-4. If sufficient, how we would calculate or derive the answer
-
+Important: if you use MCP tools, you won't see the output, so make sure your message to the small model is clear about
+exactly what information you want it to convey to you from the output.
 """
 
 REMOTE_SYNTHESIS_FINAL_MCP = """\
@@ -205,7 +50,7 @@ Here is the response after step-by-step thinking.
 {response}
 
 ### Instructions
-If you have enough information or if the task is complete, write a final answer to fullfills the task. 
+If you have enough information or if the task is complete, write a final answer to fulfill the task. 
 
 ```json
 {{
@@ -219,9 +64,11 @@ Otherwise, if the task is not complete, request the small language model to do a
 ```json
 {{
     "decision": "request_additional_info",
-    "mcp_tool_call": null,  # or, a tool call formatted in JSON as per its usage
+    "mcp_tool_calls": [],  # a list of tool calls, formatted in JSON as per their usage (can be an empty list)
     "message": "<your message to the small language model>"
 }}
 ```
 
+Important: if you use MCP tools, you won't see the output, so make sure your message to the small model is clear about
+exactly what information you want it to convey to you from the output.
 """

--- a/minions/prompts/minion_mcp.py
+++ b/minions/prompts/minion_mcp.py
@@ -1,0 +1,215 @@
+SUPERVISOR_INITIAL_PROMPT_OLD = """\
+We need to perform the following task.
+
+### Task
+{task}
+
+### Instructions
+You will not have direct access to the context, but can chat with a small language model which has read the entire thing.
+
+Feel free to think step-by-step, but eventually you must provide an output in the format below:
+
+<think step by step here>
+```json
+{{
+    "message": "<your message to the small language model. If you are asking model to do a task, make sure it is a single task!>"
+}}
+```
+"""
+
+WORKER_PRIVACY_SHIELD_PROMPT = """\
+You are a helpful assistant that is very mindful of user privacy. You are communicating with a powerful large language model that you are sharing information with. Revise the following text to preserve user privacy. We have already extracted the PII from the original document. Remove any PII from the text. Provide your output without any preamble. 
+
+### PII Extracted:
+{pii_extracted}
+
+### Text to revise:
+{output}
+
+### Revised Text:"""
+
+REFORMAT_QUERY_PROMPT = """\
+You are a helpful assistant that is very mindful of user privacy. You are communicating with a powerful large language model that you are sharing information with. Revise the following query to remove any PII. Provide your output without any preamble. DO NOT ANSWER THE QUERY, JUST REMOVE THE PII.
+
+### Extracted PII:
+{pii_extracted}
+
+### Query:
+{query}
+
+### Query without PII (remove the PII from the query, and rephrase the query if necessary):"""
+
+SUPERVISOR_CONVERSATION_PROMPT_OLD = """
+Here is the response from the small language model:
+
+### Response
+{response}
+
+
+### Instructions
+Analyze the response and think-step-by-step to determine if you have enough information to answer the question.
+
+If you have enough information or if the task is complete provide a final answer in the format below.
+
+<think step by step here>
+```json
+{{
+    "decision": "provide_final_answer", 
+    "answer": "<your answer>"
+}}
+```
+
+Otherwise, if the task is not complete, request the small language model to do additional work, by outputting the following:
+
+<think step by step here>
+```json
+{{
+    "decision": "request_additional_info",
+    "message": "<your message to the small language model>"
+}}
+```
+"""
+
+SUPERVISOR_FINAL_PROMPT_OLD = """\
+Here is the response from the small language model:
+
+### Response
+{response}
+
+
+### Instructions
+This is the final round, you cannot request additional information.
+Analyze the response and think-step-by-step and answer the question.
+
+<think step by step here>
+```json
+{{
+    "decision": "provide_final_answer",
+    "answer": "<your answer>"
+}}
+```
+DO NOT request additional information. Simply provide a final answer.
+"""
+
+WORKER_SYSTEM_PROMPT = """\
+You will help a user perform the following task.
+
+Read the context below and prepare to answer questions from an expert user. 
+### Context
+{context}
+
+### Question
+{task}
+"""
+
+SUPERVISOR_INITIAL_PROMPT = """\
+We need to perform the following task.
+
+### Task
+{task}
+
+### Instructions
+You will not have direct access to the context, but can chat with a small language model which has read the entire thing.
+
+Feel free to think step-by-step, but eventually you must provide an output in the format below:
+
+```json
+{{
+    "message": "<your message to the small language model. If you are asking model to do a task, make sure it is a single task!>"
+}}
+```
+"""
+
+SUPERVISOR_CONVERSATION_PROMPT = """
+Here is the response from the small language model:
+
+### Response
+{response}
+
+
+### Instructions
+Analyze the response and think-step-by-step to determine if you have enough information to answer the question.
+
+If you have enough information or if the task is complete provide a final answer in the format below.
+
+```json
+{{
+    "decision": "provide_final_answer", 
+    "answer": "<your answer>"
+}}
+```
+
+Otherwise, if the task is not complete, request the small language model to do additional work, by outputting the following:
+
+```json
+{{
+    "decision": "request_additional_info",
+    "message": "<your message to the small language model>"
+}}
+```
+"""
+
+SUPERVISOR_FINAL_PROMPT = """\
+Here is the response from the small language model:
+
+### Response
+{response}
+
+
+### Instructions
+This is the final round, you cannot request additional information.
+Analyze the response and think-step-by-step and answer the question.
+
+```json
+{{
+    "decision": "provide_final_answer",
+    "answer": "<your answer>"
+}}
+```
+DO NOT request additional information. Simply provide a final answer.
+"""
+
+REMOTE_SYNTHESIS_COT = """
+Here is the response from the small language model:
+
+### Response
+{response}
+
+
+### Instructions
+Analyze the response and think-step-by-step to determine if you have enough information to answer the question.
+
+Think about:
+1. What information we have gathered
+2. Whether it is sufficient to answer the question
+3. If not sufficient, what specific information is missing
+4. If sufficient, how we would calculate or derive the answer
+
+"""
+
+REMOTE_SYNTHESIS_FINAL = """\
+Here is the response after step-by-step thinking.
+
+### Response
+{response}
+
+### Instructions
+If you have enough information or if the task is complete, write a final answer to fullfills the task. 
+
+```json
+{{
+    "decision": "provide_final_answer", 
+    "answer": "<your answer>"
+}}
+```
+
+Otherwise, if the task is not complete, request the small language model to do additional work, by outputting the following:
+
+```json
+{{
+    "decision": "request_additional_info",
+    "message": "<your message to the small language model>"
+}}
+```
+
+"""

--- a/minions/utils/minion_mcp_examples.py
+++ b/minions/utils/minion_mcp_examples.py
@@ -10,7 +10,7 @@ from minions.minion import Minion
 from minions.minions_mcp import SyncMCPClient, MCPConfigManager
 
 PROJECT_DIR = pathlib.Path(__file__).parent.parent.parent
-LOG_DIR = PROJECT_DIR / "minions_logs"
+LOG_DIR = PROJECT_DIR / "minion_logs"
 MCP_CONFIG_PATH = PROJECT_DIR / "mcp.json"
 
 

--- a/minions/utils/minion_mcp_examples.py
+++ b/minions/utils/minion_mcp_examples.py
@@ -1,0 +1,129 @@
+import os
+import pathlib
+import subprocess
+import sys
+
+from minions.clients.ollama import OllamaClient
+import time
+from minions.clients.openai import OpenAIClient
+from minions.minion import Minion
+from minions.minions_mcp import SyncMCPClient, MCPConfigManager
+
+MCP_CONFIG_PATH = "/Users/thomasbreydo/dev/minions/mcp.json"
+
+LOG_DIR = pathlib.Path(__file__).parent.parent / "minions_logs"
+
+
+def _start_github_mcp_server(server_config_manager: MCPConfigManager):
+    command = server_config_manager.servers["github"].command
+    args = server_config_manager.servers["github"].args
+    env = os.environ.copy() | server_config_manager.servers["github"].env
+    subprocess.Popen([command, *args], stderr=sys.stderr, stdout=sys.stdout, env=env)
+
+
+def _start_filesystem_mcp_server(server_config_manager: MCPConfigManager):
+    command = server_config_manager.servers["filesystem"].command
+    args = server_config_manager.servers["filesystem"].args
+    subprocess.Popen([command, *args], stderr=sys.stderr, stdout=sys.stdout)
+
+
+def example_mcp_unnecessary():
+    # context = """
+    # Patient John Doe is a 60-year-old male with a history of hypertension. In his latest checkup, his blood pressure was recorded at 160/100 mmHg, and he reported occasional chest discomfort during physical activity.
+    # Recent laboratory results show that his LDL cholesterol level is elevated at 170 mg/dL, while his HDL remains within the normal range at 45 mg/dL. Other metabolic indicators, including fasting glucose and renal function, are unremarkable.
+    # """
+
+    # task = "Based on the patient's blood pressure and LDL cholesterol readings in the context, evaluate whether these factors together suggest an increased risk for cardiovascular complications."
+    pass
+
+
+def _start_clients() -> tuple[OllamaClient, OpenAIClient]:
+    print("Connecting to Ollama client... ")
+    local_client = OllamaClient(
+        model_name="phi4-mini",
+    )
+    print("done.")
+
+    print("Connecting to OpenAI client... ")
+    remote_client = OpenAIClient(
+        model_name="gpt-4o",
+    )
+    print("done.")
+
+    return local_client, remote_client
+
+
+def _make_filesystem_minion() -> Minion:
+    """Start filesystem MCP server and make a Minion with access to it"""
+    local_client, remote_client = _start_clients()
+
+    config_manager = MCPConfigManager(MCP_CONFIG_PATH)
+    _start_filesystem_mcp_server(config_manager)
+    mcp_client = SyncMCPClient("filesystem", config_manager)
+
+    # Instantiate the Minion object with both clients
+    return Minion(local_client, remote_client, mcp_client=mcp_client, log_dir=LOG_DIR)
+
+
+def _make_github_minion() -> Minion:
+    """Start GitHub MCP server and make a Minion with access to it"""
+    local_client, remote_client = _start_clients()
+
+    config_manager = MCPConfigManager(MCP_CONFIG_PATH)
+    _start_github_mcp_server(config_manager)
+    mcp_client = SyncMCPClient("github", config_manager)
+
+    # Instantiate the Minion object with both clients
+    return Minion(local_client, remote_client, mcp_client=mcp_client, log_dir=LOG_DIR)
+
+
+def example_local_codebase():
+    minion = _make_filesystem_minion()
+    context = ""
+    task = "Identify all files in my minions repository that contain ollama imports."
+
+    # Execute the minion protocol for up to two communication rounds
+    output = minion(
+        task=task,
+        context=[context],
+        max_rounds=10,
+        logging_id=int(time.time()),
+    )
+
+    print(output)
+
+
+def example_github():
+    minion = _make_github_minion()
+    context = "The MCP tools give access to GitHub."
+    task = "Summarize the coding profile of the user, thomasbreydo, based on their repos."
+
+    # Execute the minion protocol for up to two communication rounds
+    output = minion(
+        task=task,
+        context=[context],
+        max_rounds=10,
+        logging_id=int(time.time()),
+    )
+
+    print(output)
+
+
+def example_local_doordash():
+    minion = _make_filesystem_minion()
+    context = ""
+    task = "Summarize the contents of my latest doordash receipts."
+
+    # Execute the minion protocol for up to two communication rounds
+    output = minion(
+        task=task,
+        context=[context],
+        max_rounds=5,
+        logging_id=int(time.time()),
+    )
+
+    print(output)
+
+
+if __name__ == '__main__':
+    example_github()

--- a/minions/utils/minion_mcp_examples.py
+++ b/minions/utils/minion_mcp_examples.py
@@ -9,80 +9,44 @@ from minions.clients.openai import OpenAIClient
 from minions.minion import Minion
 from minions.minions_mcp import SyncMCPClient, MCPConfigManager
 
-MCP_CONFIG_PATH = "/Users/thomasbreydo/dev/minions/mcp.json"
+PROJECT_DIR = pathlib.Path(__file__).parent.parent.parent
+LOG_DIR = PROJECT_DIR / "minions_logs"
+MCP_CONFIG_PATH = PROJECT_DIR / "mcp.json"
 
-LOG_DIR = pathlib.Path(__file__).parent.parent / "minions_logs"
 
-
-def _start_github_mcp_server(server_config_manager: MCPConfigManager):
-    command = server_config_manager.servers["github"].command
-    args = server_config_manager.servers["github"].args
-    env = os.environ.copy() | server_config_manager.servers["github"].env
+def _start_mcp_server(server_name: str, server_config_manager: MCPConfigManager):
+    """Starts the `server_name` MCP server via the command specified in the config manager"""
+    command = server_config_manager.servers[server_name].command
+    args = server_config_manager.servers[server_name].args
+    env = os.environ.copy() | (server_config_manager.servers[server_name].env or {})
     subprocess.Popen([command, *args], stderr=sys.stderr, stdout=sys.stdout, env=env)
 
 
-def _start_filesystem_mcp_server(server_config_manager: MCPConfigManager):
-    command = server_config_manager.servers["filesystem"].command
-    args = server_config_manager.servers["filesystem"].args
-    subprocess.Popen([command, *args], stderr=sys.stderr, stdout=sys.stdout)
-
-
-def example_mcp_unnecessary():
-    # context = """
-    # Patient John Doe is a 60-year-old male with a history of hypertension. In his latest checkup, his blood pressure was recorded at 160/100 mmHg, and he reported occasional chest discomfort during physical activity.
-    # Recent laboratory results show that his LDL cholesterol level is elevated at 170 mg/dL, while his HDL remains within the normal range at 45 mg/dL. Other metabolic indicators, including fasting glucose and renal function, are unremarkable.
-    # """
-
-    # task = "Based on the patient's blood pressure and LDL cholesterol readings in the context, evaluate whether these factors together suggest an increased risk for cardiovascular complications."
-    pass
-
-
 def _start_clients() -> tuple[OllamaClient, OpenAIClient]:
-    print("Connecting to Ollama client... ")
-    local_client = OllamaClient(
-        model_name="phi4-mini",
-    )
+    print("Connecting to Ollama and OpenAI... ")
+    local_client = OllamaClient(model_name="phi4-mini")
+    remote_client = OpenAIClient(model_name="gpt-4o")
     print("done.")
-
-    print("Connecting to OpenAI client... ")
-    remote_client = OpenAIClient(
-        model_name="gpt-4o",
-    )
-    print("done.")
-
     return local_client, remote_client
 
 
-def _make_filesystem_minion() -> Minion:
-    """Start filesystem MCP server and make a Minion with access to it"""
+def _make_mcp_minion(mcp_server_name: str) -> Minion:
+    """Start MCP server (e.g. 'github' or 'filesystem') and make a Minion with access to it"""
     local_client, remote_client = _start_clients()
 
     config_manager = MCPConfigManager(MCP_CONFIG_PATH)
-    _start_filesystem_mcp_server(config_manager)
-    mcp_client = SyncMCPClient("filesystem", config_manager)
-
-    # Instantiate the Minion object with both clients
-    return Minion(local_client, remote_client, mcp_client=mcp_client, log_dir=LOG_DIR)
-
-
-def _make_github_minion() -> Minion:
-    """Start GitHub MCP server and make a Minion with access to it"""
-    local_client, remote_client = _start_clients()
-
-    config_manager = MCPConfigManager(MCP_CONFIG_PATH)
-    _start_github_mcp_server(config_manager)
-    mcp_client = SyncMCPClient("github", config_manager)
+    _start_mcp_server(mcp_server_name, config_manager)
+    mcp_client = SyncMCPClient(mcp_server_name, config_manager)
 
     # Instantiate the Minion object with both clients
     return Minion(local_client, remote_client, mcp_client=mcp_client, log_dir=LOG_DIR)
 
 
 def example_local_codebase():
-    minion = _make_filesystem_minion()
+    minion = _make_mcp_minion("filesystem")
     context = ""
     task = "Identify all files in my minions repository that contain ollama imports."
 
-    # Execute the minion protocol for up to two communication rounds
     output = minion(
         task=task,
         context=[context],
@@ -90,15 +54,14 @@ def example_local_codebase():
         logging_id=int(time.time()),
     )
 
-    print(output)
+    print(f"Final answer: {output['final_answer']}")
 
 
 def example_github():
-    minion = _make_github_minion()
+    minion = _make_mcp_minion("github")
     context = "The MCP tools give access to GitHub."
     task = "Summarize the coding profile of the user, thomasbreydo, based on their repos."
 
-    # Execute the minion protocol for up to two communication rounds
     output = minion(
         task=task,
         context=[context],
@@ -106,15 +69,29 @@ def example_github():
         logging_id=int(time.time()),
     )
 
-    print(output)
+    print(f"Final answer: {output['final_answer']}")
 
 
-def example_local_doordash():
-    minion = _make_filesystem_minion()
+def example_github_read_files():
+    minion = _make_mcp_minion("github")
+    context = "The MCP tools give access to the repo."
+    task = "Identify how many .py files are in my thomasbreydo/minions repo, including .py files in subdirectories."
+
+    output = minion(
+        task=task,
+        context=[context],
+        max_rounds=10,
+        logging_id=int(time.time()),
+    )
+
+    print(f"Final answer: {output['final_answer']}")
+
+
+def example_local():
+    minion = _make_mcp_minion("filesystem")
     context = ""
-    task = "Summarize the contents of my latest doordash receipts."
+    task = "Summarize the contents of my mcp_test directory"
 
-    # Execute the minion protocol for up to two communication rounds
     output = minion(
         task=task,
         context=[context],
@@ -122,7 +99,27 @@ def example_local_doordash():
         logging_id=int(time.time()),
     )
 
-    print(output)
+    print(f"Final answer: {output['final_answer']}")
+
+
+def example_mcp_unnecessary():
+    minion = _make_mcp_minion("filesystem")
+
+    context = """
+    Patient John Doe is a 60-year-old male with a history of hypertension. In his latest checkup, his blood pressure was recorded at 160/100 mmHg, and he reported occasional chest discomfort during physical activity.
+    Recent laboratory results show that his LDL cholesterol level is elevated at 170 mg/dL, while his HDL remains within the normal range at 45 mg/dL. Other metabolic indicators, including fasting glucose and renal function, are unremarkable.
+    """
+
+    task = "Based on the patient's blood pressure and LDL cholesterol readings in the context, evaluate whether these factors together suggest an increased risk for cardiovascular complications."
+
+    output = minion(
+        task=task,
+        context=[context],
+        max_rounds=5,
+        logging_id=int(time.time()),
+    )
+
+    print(f"Final answer: {output['final_answer']}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds the Model Context Protocol (MCP) to the Minion protocol! Essentially, the supervisor now sees the available MCP tools and can ask for them to be executed. The tool output is then passed to the minion alongside the supervisor's request.

Summary of changes:

* Introduced slightly-modified versions of the Minion prompts for the supervisor and the worker, so that they know that MCP tools are involved. All three new prompts are in `minions/prompts/minion_mcp.py`. They are only used if the `Minion` is instantiated with an `mcp_client`.
* Introduced code that executes the requested MCP tool and passes the output to the worker.
* Added several example clients for the Filesystem and GitHub servers in `minions/utils/minion_mcp_examples.py`. See functions like `example_github()` and `example_local()`.
