### PR TITLE
max_jobs_per_round override in Minions and app

### DIFF
--- a/app.py
+++ b/app.py
@@ -778,6 +778,7 @@ def run_protocol(
                 doc_metadata=doc_metadata,
                 context=[context],
                 max_rounds=5,
+                max_jobs_per_round=max_jobs_per_round,
                 use_retrieval=use_retrieval,
             )
         elif protocol == "DeepResearch":
@@ -1140,8 +1141,17 @@ with st.sidebar:
             value=False,
             help="When enabled, only the most relevant chunks of context will be examined by minions, speeding up execution",
         )
+        max_jobs_per_round = st.number_input(
+            "Max Jobs/Round",
+            min_value=1,
+            max_value=2048,
+            value=2048,
+            step=1,
+            help="Maximum number of jobs to run per round for Minions protocol",
+        )
     else:
         use_bm25 = False
+        max_jobs_per_round = 2048
 
     # Add MCP server selection when Minions-MCP is selected
     if protocol == "Minions-MCP":

--- a/minions/minions.py
+++ b/minions/minions.py
@@ -220,6 +220,7 @@ class Minions:
         doc_metadata: str,
         context: List[str],
         max_rounds=None,
+        max_jobs_per_round=None,
         num_tasks_per_round=3,
         num_samples_per_task=1,
         mcp_tools_info=None,
@@ -234,6 +235,7 @@ class Minions:
             doc_metadata: Type of document being analyzed
             context: List of context strings
             max_rounds: Override default max_rounds if provided
+            max_jobs_per_round: Override default max_jobs_per_round if provided
             retrieval: Retrieval strategy to use. Options:
                 - None: Don't use retrieval
                 - "bm25": Use BM25 keyword-based retrieval
@@ -245,6 +247,7 @@ class Minions:
         """
 
         self.max_rounds = max_rounds or self.max_rounds
+        self.max_jobs_per_round = max_jobs_per_round or self.max_jobs_per_round
 
         retriever = None
 


### PR DESCRIPTION
This PR adds support for overriding the `max_jobs_per_round` param in the Streamlit app and when invoking the Minions protocol.

This param is initialized to 2048 in the Minions constructor, but can be set to a lower value if the user wants to limit the # of jobs that will be executed in parallel due to hardware constraints. If the supervisor sends too many jobs, it should receive feedback to retry with a lower number of jobs below the current value of max_jobs_per_round.

A separate improvement not included here would be to sequentially run N jobs in smaller batches of size M < N.