### PR TITLE
feat: introduce MinionsClient base class for client unification

### DIFF
--- a/minions/clients/__init__.py
+++ b/minions/clients/__init__.py
@@ -1,3 +1,4 @@
+from minions.clients.base import MinionsClient
 from minions.clients.ollama import OllamaClient
 from minions.clients.openai import OpenAIClient
 from minions.clients.azure_openai import AzureOpenAIClient

--- a/minions/clients/anthropic.py
+++ b/minions/clients/anthropic.py
@@ -4,9 +4,10 @@ import os
 import anthropic
 
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 
 
-class AnthropicClient:
+class AnthropicClient(MinionsClient):
     def __init__(
         self,
         model_name: str = "claude-3-sonnet-20240229",
@@ -17,6 +18,7 @@ class AnthropicClient:
         include_search_queries: bool = False,
         use_caching: bool = False,
         use_code_interpreter: bool = False,
+        **kwargs
     ):
         """
         Initialize the Anthropic client.
@@ -30,13 +32,19 @@ class AnthropicClient:
             include_search_queries: Whether to include search queries in the response (default: False)
             use_caching: Whether to use caching for the client (default: False)
             use_code_interpreter: Whether to use the code interpreter (default: False)
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
-        self.api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
-        self.logger = logging.getLogger("AnthropicClient")
+        super().__init__(
+            model_name=model_name,
+            api_key=api_key,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         self.logger.setLevel(logging.INFO)
-        self.temperature = temperature
-        self.max_tokens = max_tokens
+        self.api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
         self.use_web_search = use_web_search
         self.include_search_queries = include_search_queries
         self.use_code_interpreter = use_code_interpreter

--- a/minions/clients/azure_openai.py
+++ b/minions/clients/azure_openai.py
@@ -6,9 +6,10 @@ import openai
 from openai import AzureOpenAI
 
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 
 
-class AzureOpenAIClient:
+class AzureOpenAIClient(MinionsClient):
     def __init__(
         self,
         model_name: str = "gpt-4o",
@@ -17,6 +18,7 @@ class AzureOpenAIClient:
         azure_endpoint: Optional[str] = None,
         temperature: float = 0.0,
         max_tokens: int = 4096,
+        **kwargs
     ):
         """
         Initialize the Azure OpenAI client.
@@ -28,8 +30,18 @@ class AzureOpenAIClient:
             azure_endpoint: Azure OpenAI endpoint URL (optional, falls back to environment variable if not provided)
             temperature: Sampling temperature (default: 0.0)
             max_tokens: Maximum number of tokens to generate (default: 4096)
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
+        super().__init__(
+            model_name=model_name,
+            api_key=api_key,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs
+        )
+        
+        # Client-specific configuration
+        self.logger.setLevel(logging.INFO)
         self.api_key = api_key or os.getenv("AZURE_OPENAI_API_KEY")
         self.api_version = api_version or os.getenv("AZURE_OPENAI_API_VERSION", "2024-02-15-preview")
         self.azure_endpoint = azure_endpoint or os.getenv("AZURE_OPENAI_ENDPOINT")
@@ -46,11 +58,6 @@ class AzureOpenAIClient:
             api_version=self.api_version,
             azure_endpoint=self.azure_endpoint,
         )
-        
-        self.logger = logging.getLogger("AzureOpenAIClient")
-        self.logger.setLevel(logging.INFO)
-        self.temperature = temperature
-        self.max_tokens = max_tokens
 
     def chat(self, messages: List[Dict[str, Any]], **kwargs) -> Tuple[List[str], Usage]:
         """

--- a/minions/clients/base.py
+++ b/minions/clients/base.py
@@ -1,0 +1,141 @@
+"""
+Base abstract client class for all minions clients.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from minions.usage import Usage
+
+
+class MinionsClient(ABC):
+    """
+    Abstract base class for all minions clients.
+    
+    This class defines the common interface that all clients must implement
+    and provides shared initialization and utility methods.
+    """
+    
+    def __init__(
+        self,
+        model_name: str,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        verbose: Optional[bool] = None,
+        **kwargs
+    ):
+        """
+        Initialize the client with common parameters.
+        
+        Args:
+            model_name: Name/identifier of the model to use (required)
+            temperature: Sampling temperature (optional, client-specific defaults apply)
+            max_tokens: Maximum number of tokens to generate (optional, client-specific defaults apply)
+            api_key: API key for authentication (optional, if required by client)
+            base_url: Custom API endpoint URL (optional, if supported by client)
+            verbose: Enable verbose logging/output (optional, client-specific defaults apply)
+            **kwargs: Additional client-specific parameters
+        """
+        self.model_name = model_name
+        self.logger = logging.getLogger(self.__class__.__name__)
+        
+        # Only set attributes if they were explicitly provided
+        if temperature is not None:
+            self.temperature = temperature
+        if max_tokens is not None:
+            self.max_tokens = max_tokens
+        if api_key is not None:
+            self.api_key = api_key
+        if base_url is not None:
+            self.base_url = base_url
+        if verbose is not None:
+            self.verbose = verbose
+            # Set logging level based on verbose flag if provided
+            if verbose:
+                self.logger.setLevel(logging.INFO)
+        
+        # Store additional kwargs for client-specific initialization
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+    
+    @abstractmethod
+    def chat(
+        self, 
+        messages: List[Dict[str, Any]], 
+        **kwargs
+    ) -> Tuple[List[str], Usage, ...]:
+        """
+        Primary chat interface that all clients must implement.
+        
+        Args:
+            messages: List of message dictionaries with 'role' and 'content' keys
+            **kwargs: Additional parameters specific to the client
+            
+        Returns:
+            Tuple containing at minimum:
+            - List[str]: Generated responses
+            - Usage: Token usage information
+            
+            May also include:
+            - List[str]: Finish reasons (optional)
+            - List[Any]: Tool calls (optional)
+        """
+        pass
+    
+    def embed(
+        self, 
+        content: Union[str, List[str]], 
+        **kwargs
+    ) -> List[List[float]]:
+        """
+        Generate embeddings for the given content.
+        
+        Args:
+            content: Text content to embed (single string or list of strings)
+            **kwargs: Additional parameters specific to the client
+            
+        Returns:
+            List of embedding vectors
+            
+        Raises:
+            NotImplementedError: If the client doesn't support embeddings
+        """
+        raise NotImplementedError(f"Embedding not supported by {self.__class__.__name__}")
+    
+    def complete(
+        self, 
+        prompts: Union[str, List[str]], 
+        **kwargs
+    ) -> Tuple[List[str], Usage]:
+        """
+        Generate text completions for the given prompts.
+        
+        Args:
+            prompts: Prompt text(s) to complete
+            **kwargs: Additional parameters specific to the client
+            
+        Returns:
+            Tuple of:
+            - List[str]: Generated completions
+            - Usage: Token usage information
+            
+        Raises:
+            NotImplementedError: If the client doesn't support text completion
+        """
+        raise NotImplementedError(f"Text completion not supported by {self.__class__.__name__}")
+    
+    def __str__(self) -> str:
+        """String representation of the client."""
+        return f"{self.__class__.__name__}(model={self.model_name})"
+    
+    def __repr__(self) -> str:
+        """Detailed string representation of the client."""
+        attrs = [f"model_name='{self.model_name}'"]
+        if hasattr(self, 'temperature'):
+            attrs.append(f"temperature={self.temperature}")
+        if hasattr(self, 'max_tokens'):
+            attrs.append(f"max_tokens={self.max_tokens}")
+        return f"{self.__class__.__name__}({', '.join(attrs)})"

--- a/minions/clients/cartesia_mlx.py
+++ b/minions/clients/cartesia_mlx.py
@@ -4,10 +4,11 @@ from typing import Any, Dict, List, Optional, Tuple, Iterator
 import cartesia_mlx as cmx
 import mlx.core as mx
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 from transformers import AutoTokenizer
 
 
-class CartesiaMLXClient:
+class CartesiaMLXClient(MinionsClient):
     def __init__(
         self,
         model_name: str = "cartesia-ai/Llamba-1B-4bit-mlx",
@@ -15,6 +16,7 @@ class CartesiaMLXClient:
         max_tokens: int = 100,
         verbose: bool = False,
         dtype: str = "float32",
+        **kwargs
     ):
         """
         Initialize the Cartesia MLX client.
@@ -25,13 +27,18 @@ class CartesiaMLXClient:
             max_tokens: Maximum number of tokens to generate (default: 1000)
             verbose: Whether to print tokens and timing information (default: False)
             dtype: Data type for model computation (default: "float32")
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
-        self.logger = logging.getLogger("CartesiaMLXClient")
+        super().__init__(
+            model_name=model_name,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            verbose=verbose,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         self.logger.setLevel(logging.INFO)
-        self.temperature = temperature
-        self.max_tokens = max_tokens
-        self.verbose = verbose
         self.dtype = dtype
 
         # Load the model

--- a/minions/clients/deepseek.py
+++ b/minions/clients/deepseek.py
@@ -2,9 +2,11 @@ from typing import Any, Dict, List, Optional, Tuple
 from minions.usage import Usage
 import logging
 import os
-import openai 
+import openai
 
-class DeepSeekClient:
+from minions.clients.base import MinionsClient
+
+class DeepSeekClient(MinionsClient):
     def __init__(
         self,
         model_name: str = "deepseek-chat",
@@ -12,8 +14,9 @@ class DeepSeekClient:
         temperature: float = 0.0,
         max_tokens: int = 4096,
         base_url: str = "https://api.deepseek.com",
+        **kwargs
     ):
-        '''
+        """
         Initialize the DeepSeek client.
 
         Args:
@@ -21,14 +24,21 @@ class DeepSeekClient:
             api_key: DeepSeek API key (optional, falls back to environment variable if not provided)
             temperature: Sampling temperature (default: 0.0)
             max_tokens: Maximum number of tokens to generate (default: 4096)
-        '''
-        self.model_name = model_name
-        openai.api_key = api_key or os.getenv("DEEPSEEK_API_KEY")
-        self.logger = logging.getLogger("DeepSeekClient")
+            base_url: DeepSeek API base URL (default: "https://api.deepseek.com")
+            **kwargs: Additional parameters passed to base class
+        """
+        super().__init__(
+            model_name=model_name,
+            api_key=api_key,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            base_url=base_url,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         self.logger.setLevel(logging.INFO)
-        self.temperature = temperature
-        self.max_tokens = max_tokens
-        self.base_url = base_url
+        openai.api_key = api_key or os.getenv("DEEPSEEK_API_KEY")
     def chat(self, messages: List[Dict[str, Any]], **kwargs) -> Tuple[List[str], Usage]:
         '''
         Handle chat completions using the DeepSeek API.

--- a/minions/clients/gemini.py
+++ b/minions/clients/gemini.py
@@ -5,9 +5,10 @@ from typing import Any, Dict, List, Optional, Union, Tuple
 import os
 
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 
 
-class GeminiClient:
+class GeminiClient(MinionsClient):
     def __init__(
         self,
         model_name: str = "gemini-2.0-flash",
@@ -20,6 +21,7 @@ class GeminiClient:
         system_instruction: Optional[str] = None,
         use_openai_api: bool = False,
         thinking_budget: Optional[int] = None,
+        **kwargs
     ):
         """Initialize Gemini Client.
 
@@ -33,13 +35,19 @@ class GeminiClient:
             tool_calling: Whether to support tool calling.
             system_instruction: Optional system instruction to use for all calls.
             use_openai_api: Whether to use OpenAI-compatible API endpoint for Gemini models.
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
-        self.logger = logging.getLogger("GeminiClient")
+        super().__init__(
+            model_name=model_name,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            api_key=api_key,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         self.logger.setLevel(logging.INFO)
 
-        self.temperature = temperature
-        self.max_tokens = max_tokens
         self.api_key = api_key or os.getenv("GOOGLE_API_KEY")
         self.use_async = use_async
         self.return_tools = tool_calling

--- a/minions/clients/grok.py
+++ b/minions/clients/grok.py
@@ -1,11 +1,12 @@
 from typing import Any, Dict, List, Optional, Tuple
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 import logging
 import os
 import openai
 
 
-class GrokClient:
+class GrokClient(MinionsClient):
     def __init__(
         self,
         model_name: str = "grok-3-beta",
@@ -13,23 +14,32 @@ class GrokClient:
         temperature: float = 0.0,
         max_tokens: int = 4096,
         base_url: str = "https://api.x.ai/v1",
+        **kwargs
     ):
         """
-        Initialize the DeepSeek client.
+        Initialize the Grok client.
 
         Args:
-            model_name: The name of the model to use (default: "deepseek-chat")
-            api_key: DeepSeek API key (optional, falls back to environment variable if not provided)
+            model_name: The name of the model to use (default: "grok-3-beta")
+            api_key: Grok API key (optional, falls back to environment variable if not provided)
             temperature: Sampling temperature (default: 0.0)
             max_tokens: Maximum number of tokens to generate (default: 4096)
+            base_url: Base URL for the Grok API (default: "https://api.x.ai/v1")
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
-        openai.api_key = api_key or os.getenv("XAI_API_KEY")
-        self.logger = logging.getLogger("GrokClient")
+        super().__init__(
+            model_name=model_name,
+            api_key=api_key,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            base_url=base_url,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         self.logger.setLevel(logging.INFO)
-        self.temperature = temperature
-        self.max_tokens = max_tokens
-        self.base_url = base_url
+        openai.api_key = api_key or os.getenv("XAI_API_KEY")
+        # self.base_url = base_url # Handled by base
 
     def chat(self, messages: List[Dict[str, Any]], **kwargs) -> Tuple[List[str], Usage]:
         """

--- a/minions/clients/groq.py
+++ b/minions/clients/groq.py
@@ -4,15 +4,17 @@ import os
 from groq import Groq
 
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 
 
-class GroqClient:
+class GroqClient(MinionsClient):
     def __init__(
         self,
         model_name: str = "llama-3.3-70b-versatile",
         api_key: Optional[str] = None,
         temperature: float = 0.0,
         max_tokens: int = 2048,
+        **kwargs
     ):
         """
         Initialize the Groq client.
@@ -22,13 +24,19 @@ class GroqClient:
             api_key: Groq API key (optional, falls back to environment variable if not provided)
             temperature: Sampling temperature (default: 0.0)
             max_tokens: Maximum number of tokens to generate (default: 2048)
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
-        self.api_key = api_key or os.getenv("GROQ_API_KEY")
-        self.logger = logging.getLogger("GroqClient")
+        super().__init__(
+            model_name=model_name,
+            api_key=api_key,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         self.logger.setLevel(logging.INFO)
-        self.temperature = temperature
-        self.max_tokens = max_tokens
+        self.api_key = api_key or os.getenv("GROQ_API_KEY")
         self.client = Groq(api_key=self.api_key)
 
     def chat(self, messages: List[Dict[str, Any]], **kwargs) -> Tuple[List[str], Usage]:

--- a/minions/clients/huggingface.py
+++ b/minions/clients/huggingface.py
@@ -11,16 +11,18 @@ import numpy as np
 from huggingface_hub import InferenceClient, AsyncInferenceClient
 
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 from minions.clients.utils import ServerMixin
 
 
-class HuggingFaceClient:
+class HuggingFaceClient(MinionsClient):
     def __init__(
         self,
         model_name: str = "meta-llama/Llama-3.2-3B-Instruct",
         temperature: float = 0.2,
         max_tokens: int = 2048,
         api_token: Optional[str] = None,
+        **kwargs
     ):
         """
         Initialize the HuggingFace client.
@@ -30,12 +32,17 @@ class HuggingFaceClient:
             temperature: Sampling temperature (default: 0.2)
             max_tokens: Maximum number of tokens to generate (default: 2048)
             api_token: HuggingFace API token (optional, falls back to HF_TOKEN environment variable)
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
-        self.logger = logging.getLogger("HuggingFaceClient")
+        super().__init__(
+            model_name=model_name,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         self.logger.setLevel(logging.INFO)
-        self.temperature = temperature
-        self.max_tokens = max_tokens
 
         # Get API token from parameter or environment variable
         self.api_token = api_token or os.getenv("HF_TOKEN")

--- a/minions/clients/llama_api.py
+++ b/minions/clients/llama_api.py
@@ -1,11 +1,12 @@
 from typing import Any, Dict, List, Optional, Tuple
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 import logging
 import os
 import openai
 
 
-class LlamaApiClient:
+class LlamaApiClient(MinionsClient):
     def __init__(
         self,
         model_name: str = "Llama-4-Maverick-17B-128E-Instruct-FP8",
@@ -13,6 +14,7 @@ class LlamaApiClient:
         temperature: float = 0.0,
         max_tokens: int = 4096,
         base_url: str = "https://api.llama.com/compat/v1/",
+        **kwargs
     ):
         """
         Initialize the LlamaAPI client.
@@ -22,14 +24,22 @@ class LlamaApiClient:
             api_key: LlamaAPI API key (optional, falls back to environment variable if not provided)
             temperature: Sampling temperature (default: 0.0)
             max_tokens: Maximum number of tokens to generate (default: 4096)
+            base_url: Base URL for the LlamaAPI (default: "https://api.llama.com/compat/v1/")
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
-        openai.api_key = api_key or os.getenv("LLAMA_API_KEY")
-        self.logger = logging.getLogger("LlamaApiClient")
+        super().__init__(
+            model_name=model_name,
+            api_key=api_key,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            base_url=base_url,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         self.logger.setLevel(logging.INFO)
-        self.temperature = temperature
-        self.max_tokens = max_tokens
-        self.base_url = base_url
+        openai.api_key = api_key or os.getenv("LLAMA_API_KEY")
+        # self.base_url = base_url # Handled by base
 
     def chat(self, messages: List[Dict[str, Any]], **kwargs) -> Tuple[List[str], Usage]:
         """

--- a/minions/clients/llamacpp.py
+++ b/minions/clients/llamacpp.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from typing import Any, Dict, List, Optional, Tuple, Union
+from pathlib import Path
 
 try:
     from llama_cpp import Llama
@@ -17,33 +18,46 @@ except ImportError:
     )
 
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 
 
-class LlamaCppClient:
+class LlamaCppClient(MinionsClient):
     def __init__(
         self,
         model_path: str = None,
-        chat_format: str = "chatml",
+        model_name: Optional[str] = None,
         temperature: float = 0.0,
         max_tokens: int = 2048,
-        n_ctx: int = 4096,
+        chat_format: str = "llama-3",
+        n_ctx: int = 0,
         n_gpu_layers: int = 0,
         embedding: bool = False,
         json_output: bool = False,
         tool_calling: bool = False,
         model_repo_id: Optional[str] = None,
-        model_file_pattern: Optional[str] = None,
+        model_file_pattern: Optional[str] = "*.gguf",
         hf_token: Optional[str] = None,
+        verbose: Optional[bool] = None,
+        seed: int = -1,
+        logits_all: bool = False,
+        n_threads: Optional[int] = None,
+        n_batch: int = 512,
+        rope_freq_base: float = 0.0,
+        rope_freq_scale: float = 0.0,
+        mul_mat_q: bool = True,
+        offload_kqv: bool = True,
+        flash_attn: bool = False,
         **kwargs,
     ):
         """Initialize LlamaCpp Client with a simpler interface.
 
         Args:
             model_path: Path to the model file
-            chat_format: Chat format to use (default: "chatml")
+            model_name: Explicit model name if different from path/repo
             temperature: Sampling temperature (default: 0.0)
             max_tokens: Maximum tokens to generate (default: 2048)
-            n_ctx: Context window size (default: 4096)
+            chat_format: Chat format to use (default: "llama-3")
+            n_ctx: Context window size (default: 0, from model)
             n_gpu_layers: Number of layers to offload to GPU (default: 0)
             embedding: Enable embedding generation (default: False)
             json_output: Whether to format responses as JSON (default: False)
@@ -51,44 +65,100 @@ class LlamaCppClient:
             model_repo_id: Hugging Face model repo ID for downloading models
             model_file_pattern: File pattern for HF model (e.g., "*q4_0.gguf")
             hf_token: Hugging Face token for accessing gated models
+            verbose: Explicitly declare verbose for super()
+            seed: Seed for random number generation
+            logits_all: Whether to return all logits
+            n_threads: Number of threads to use
+            n_batch: Batch size for processing
+            rope_freq_base: Rope frequency base
+            rope_freq_scale: Rope frequency scale
+            mul_mat_q: Whether to multiply matrix q
+            offload_kqv: Whether to offload kqv
+            flash_attn: Whether to use flash attention
             **kwargs: Additional arguments for Llama constructor
         """
-        self.logger = logging.getLogger("LlamaCppClient")
-        self.logger.setLevel(logging.INFO)
-        self.temperature = temperature
-        self.max_tokens = max_tokens
-        self.n_ctx = n_ctx
-        self.chat_format = chat_format
-        self.embedding = embedding
-        self.json_output = json_output
-        self.return_tools = tool_calling
-        self.hf_token = hf_token or os.environ.get("HF_TOKEN")
+        # LlamaCpp uses model_path instead of model_name, so we need special handling
+        effective_model_name = model_name or model_path or model_repo_id or "llamacpp-model"
+        
+        super().__init__(
+            model_name=effective_model_name,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            model_path=model_path,
+            chat_format=chat_format,
+            n_ctx=n_ctx,
+            n_gpu_layers=n_gpu_layers,
+            embedding=embedding,
+            json_output=json_output,
+            tool_calling=tool_calling,
+            model_repo_id=model_repo_id,
+            model_file_pattern=model_file_pattern,
+            hf_token=hf_token,
+            verbose=verbose,
+            seed=seed,
+            logits_all=logits_all,
+            n_threads=n_threads,
+            n_batch=n_batch,
+            rope_freq_base=rope_freq_base,
+            rope_freq_scale=rope_freq_scale,
+            mul_mat_q=mul_mat_q,
+            offload_kqv=offload_kqv,
+            flash_attn=flash_attn,
+            **kwargs
+        )
+        
+        # Client-specific configuration
+        # self.logger.setLevel(logging.INFO) # Logger level is set by super() if verbose is True
 
-        # Ensure either model_path or model_repo_id is provided
-        if model_path is None and model_repo_id is None:
-            raise ValueError("Either model_path or model_repo_id must be provided")
+        # Attributes like self.n_ctx, self.chat_format, self.temperature, etc.,
+        # are now set by super().__init__()
+        
+        # Prepare arguments for Llama constructor from self's attributes
+        llama_constructor_args = {}
+        
+        # List of valid Llama constructor parameters expected to be set on self
+        valid_llama_params = [
+            "model_path", "n_ctx", "n_gpu_layers", "embedding", "chat_format", 
+            "logits_all", "verbose", "seed", "n_threads", "n_batch", 
+            "rope_freq_base", "rope_freq_scale", "mul_mat_q", "offload_kqv", "flash_attn",
+            "main_gpu", "tensor_split", "vocab_only", "use_mmap", "use_mlock" # Add more as needed
+        ]
 
-        # If model_repo_id is provided, download the model from Hugging Face
-        if model_repo_id:
-            model_path = self._download_from_hf(model_repo_id, model_file_pattern)
+        for param_name in valid_llama_params:
+            if hasattr(self, param_name) and getattr(self, param_name) is not None:
+                # Special handling for verbose: Llama expects bool, base sets self.verbose (which can be None)
+                if param_name == "verbose":
+                     llama_constructor_args[param_name] = bool(self.verbose) if self.verbose is not None else (logging.root.level == logging.DEBUG) # Llama's default for verbose
+                else:
+                    llama_constructor_args[param_name] = getattr(self, param_name)
+        
+        # Ensure model_path is present if not downloading
+        effective_model_path = getattr(self, 'model_path', None)
 
-        self.model_path = model_path
-        self.logger.info(f"Loading model from {model_path}")
-
-        # Initialize the Llama model
-        try:
-            self.llm = Llama(
-                model_path=model_path,
-                chat_format=chat_format,
-                n_ctx=n_ctx,
-                n_gpu_layers=n_gpu_layers,
-                embedding=embedding,
-                **kwargs,
+        if self.model_repo_id and not (effective_model_path and Path(effective_model_path).exists()):
+            self.logger.info(
+                f"Model path {effective_model_path} not found or not provided. Downloading from {self.model_repo_id}"
             )
-            self.logger.info(f"Successfully loaded model {model_path}")
-        except Exception as e:
-            self.logger.error(f"Failed to load model: {e}")
-            raise
+            downloaded_path = hf_hub_download(
+                repo_id=self.model_repo_id,
+                filename=self.model_file_pattern, # This might need to be more specific if multiple files match
+                local_dir=os.path.join(os.getcwd(), "models"), # Ensure 'models' dir exists or is created
+                local_dir_use_symlinks=False,
+                token=getattr(self, 'hf_token', None),
+            )
+            llama_constructor_args["model_path"] = downloaded_path
+            self.model_path = downloaded_path # Update self.model_path for consistency
+            self.logger.info(f"Model downloaded to {downloaded_path}")
+        elif not effective_model_path:
+            raise ValueError(
+                "LlamaCppClient requires either a valid 'model_path' or 'model_repo_id' for model download."
+            )
+        else:
+            # Use the existing model_path if it's valid and no download is needed
+            llama_constructor_args["model_path"] = effective_model_path
+
+
+        self.model = Llama(**llama_constructor_args)
 
     def _download_from_hf(
         self, repo_id: str, file_pattern: Optional[str] = None
@@ -180,7 +250,7 @@ class LlamaCppClient:
             print(messages)
 
             # Create the chat completion
-            response = self.llm.create_chat_completion(**completion_kwargs)
+            response = self.model.create_chat_completion(**completion_kwargs)
 
             # Extract content from response
             content = response["choices"][0]["message"]["content"]
@@ -242,7 +312,7 @@ class LlamaCppClient:
                     completion_kwargs["stop"] = kwargs["stop"]
 
                 # Create the completion
-                response = self.llm.create_completion(**completion_kwargs)
+                response = self.model.create_completion(**completion_kwargs)
 
                 # Extract content and append to responses
                 text = response["choices"][0]["text"]
@@ -286,7 +356,7 @@ class LlamaCppClient:
 
         try:
             for text in content:
-                embedding = self.llm.embed(text)
+                embedding = self.model.embed(text)
                 embeddings.append(embedding)
 
         except Exception as e:

--- a/minions/clients/mistral.py
+++ b/minions/clients/mistral.py
@@ -4,9 +4,10 @@ import os
 from mistralai import Mistral
 
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 
 
-class MistralClient:
+class MistralClient(MinionsClient):
     def __init__(
         self,
         model_name: str = "mistral-large-latest",
@@ -15,6 +16,7 @@ class MistralClient:
         max_tokens: int = 2048,
         websearch_agent: bool = False,
         websearch_premium: bool = False,
+        **kwargs
     ):
         """
         Initialize the Mistral client.
@@ -24,15 +26,21 @@ class MistralClient:
             api_key: Mistral API key (optional, falls back to environment variable if not provided)
             temperature: Sampling temperature (default: 0.0)
             max_tokens: Maximum number of tokens to generate (default: 2048)
-            enable_websearch: Whether to enable websearch capabilities (default: False)
+            websearch_agent: Whether to enable websearch capabilities (default: False)
             websearch_premium: Whether to use premium websearch with news agencies (default: False)
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
-        self.api_key = api_key or os.getenv("MISTRAL_API_KEY")
-        self.logger = logging.getLogger("MistralClient")
+        super().__init__(
+            model_name=model_name,
+            api_key=api_key,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         self.logger.setLevel(logging.INFO)
-        self.temperature = temperature
-        self.max_tokens = max_tokens
+        self.api_key = api_key or os.getenv("MISTRAL_API_KEY")
         self.enable_websearch = websearch_agent
         self.websearch_premium = websearch_premium
         self.client = Mistral(api_key=self.api_key)

--- a/minions/clients/mlx_audio.py
+++ b/minions/clients/mlx_audio.py
@@ -3,8 +3,10 @@ import os
 import tempfile
 from typing import Optional, Union, BinaryIO, Literal
 
+from minions.clients.base import MinionsClient
 
-class MLXAudioClient:
+
+class MLXAudioClient(MinionsClient):
     """
     Client for interacting with the mlx-audio library for text-to-speech generation.
 
@@ -21,6 +23,7 @@ class MLXAudioClient:
         speed: float = 1.0,
         lang_code: Optional[str] = "a",
         verbose: bool = False,
+        **kwargs
     ):
         """
         Initialize the MLX Audio client.
@@ -31,14 +34,18 @@ class MLXAudioClient:
             speed: Speech speed multiplier (default: 1.0)
             lang_code: Language code (default: "a" for Kokoro's af_heart voice)
             verbose: Whether to print verbose output (default: False)
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
-        self.voice = voice
-        self.speed = speed
-        self.lang_code = lang_code
-        self.verbose = verbose
-
-        self.logger = logging.getLogger("MLXAudioClient")
+        super().__init__(
+            model_name=model_name,
+            verbose=verbose,
+            voice=voice,
+            speed=speed,
+            lang_code=lang_code,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         self.logger.setLevel(logging.INFO if verbose else logging.WARNING)
 
         # Check if mlx-audio is installed

--- a/minions/clients/mlx_lm.py
+++ b/minions/clients/mlx_lm.py
@@ -4,9 +4,10 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from mlx_lm import generate, load
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 
 
-class MLXLMClient:
+class MLXLMClient(MinionsClient):
     def __init__(
         self,
         model_name: str = "mlx-community/Llama-3.2-3B-Instruct",
@@ -15,6 +16,7 @@ class MLXLMClient:
         verbose: bool = False,
         use_async: bool = False,
         enable_thinking: bool = False,
+        **kwargs
     ):
         """
         Initialize the MLX LM client.
@@ -25,13 +27,18 @@ class MLXLMClient:
             max_tokens: Maximum number of tokens to generate (default: 1000)
             verbose: Whether to print tokens and timing information (default: False)
             use_async: Whether to use async mode (default: False)
+            enable_thinking: Whether to enable thinking mode (default: False)
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
-        self.logger = logging.getLogger("MLXLMClient")
-        self.logger.setLevel(logging.INFO)
-        self.temperature = temperature
-        self.max_tokens = max_tokens
-        self.verbose = verbose
+        super().__init__(
+            model_name=model_name,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            verbose=verbose,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         self.use_async = use_async
         self.enable_thinking = enable_thinking
         # Load the model and tokenizer

--- a/minions/clients/mlx_omni.py
+++ b/minions/clients/mlx_omni.py
@@ -3,9 +3,10 @@ import os
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 
 
-class MLXOmniClient:
+class MLXOmniClient(MinionsClient):
     """
     Client for interacting with MLX Omni Server using TestClient method.
     This allows direct interaction with the application without starting a server.
@@ -19,6 +20,7 @@ class MLXOmniClient:
         temperature: float = 0.0,
         max_tokens: int = 2048,
         use_test_client: bool = True,
+        **kwargs
     ):
         """
         Initialize the MLX Omni client.
@@ -28,14 +30,17 @@ class MLXOmniClient:
             temperature: Sampling temperature (default: 0.0)
             max_tokens: Maximum number of tokens to generate (default: 2048)
             use_test_client: Whether to use TestClient (True) or HTTP client (False)
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
-        self.temperature = temperature
-        self.max_tokens = max_tokens
+        super().__init__(
+            model_name=model_name,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         self.use_test_client = use_test_client
-
-        self.logger = logging.getLogger("MLXOmniClient")
-        self.logger.setLevel(logging.INFO)
 
         # Initialize the client
         self._initialize_client()

--- a/minions/clients/mlx_parallm_model.py
+++ b/minions/clients/mlx_parallm_model.py
@@ -10,15 +10,17 @@ except ImportError:
     )
 
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 
 
-class MLXParallmClient:
+class MLXParallmClient(MinionsClient):
     def __init__(
         self,
         model_name: str = "mlx-community/Meta-Llama-3-8B-Instruct-4bit",
         temperature: float = 0.0,
         max_tokens: int = 100,
         verbose: bool = False,
+        **kwargs
     ):
         """
         Initialize the MLX PARALLM client.
@@ -28,14 +30,17 @@ class MLXParallmClient:
             temperature: Sampling temperature (default: 0.0)
             max_tokens: Maximum number of tokens to generate (default: 100)
             verbose: Whether to print verbose output (default: False)
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
-        self.temperature = temperature
-        self.max_tokens = max_tokens
-        self.verbose = verbose
-
-        self.logger = logging.getLogger("MLXParallmClient")
-        self.logger.setLevel(logging.INFO)
+        super().__init__(
+            model_name=model_name,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            verbose=verbose,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         self.logger.info(f"Loading MLX PARALLM model: {model_name}")
 
         self.model, self.tokenizer = load(model_name)

--- a/minions/clients/ollama.py
+++ b/minions/clients/ollama.py
@@ -4,9 +4,10 @@ from pydantic import BaseModel
 from typing import Any, Dict, List, Optional, Union, Tuple
 
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 
 
-class OllamaClient:
+class OllamaClient(MinionsClient):
     def __init__(
         self,
         model_name: str = "llama-3.2",
@@ -17,14 +18,29 @@ class OllamaClient:
         use_async: bool = False,
         tool_calling: bool = False,
         thinking: bool = False,
+        **kwargs
     ):
-        """Initialize Ollama Client."""
-        self.model_name = model_name
-        self.logger = logging.getLogger("OllamaClient")
-        self.logger.setLevel(logging.INFO)
-
-        self.temperature = temperature
-        self.max_tokens = max_tokens
+        """Initialize Ollama Client.
+        
+        Args:
+            model_name: The Ollama model to use (default: "llama-3.2")
+            temperature: Sampling temperature (default: 0.0)
+            max_tokens: Maximum number of tokens to generate (default: 2048)
+            num_ctx: Context window size (default: 48000)
+            structured_output_schema: Optional Pydantic model for structured output
+            use_async: Whether to use async API calls (default: False)
+            tool_calling: Whether to support tool calling (default: False)
+            thinking: Whether to enable thinking mode (default: False)
+            **kwargs: Additional parameters passed to base class
+        """
+        super().__init__(
+            model_name=model_name,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         self.num_ctx = num_ctx
 
         if self.model_name == "granite3.2-vision":

--- a/minions/clients/openai.py
+++ b/minions/clients/openai.py
@@ -4,10 +4,11 @@ import os
 import openai
 
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 
 
 # TODO: define one dataclass for what is returned from all the clients
-class OpenAIClient:
+class OpenAIClient(MinionsClient):
     def __init__(
         self,
         model_name: str = "gpt-4o",
@@ -18,6 +19,7 @@ class OpenAIClient:
         use_responses_api: bool = False,
         tools: List[Dict[str, Any]] = None,
         reasoning_effort: str = "low",
+        **kwargs
     ):
         """
         Initialize the OpenAI client.
@@ -28,13 +30,23 @@ class OpenAIClient:
             temperature: Sampling temperature (default: 0.0)
             max_tokens: Maximum number of tokens to generate (default: 4096)
             base_url: Base URL for the OpenAI API (optional, falls back to OPENAI_BASE_URL environment variable or default URL)
+            use_responses_api: Whether to use responses API for o1-pro models (default: False)
+            tools: List of tools for function calling (default: None)
+            reasoning_effort: Reasoning effort level for o1 models (default: "low")
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
-        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
-        self.logger = logging.getLogger("OpenAIClient")
+        super().__init__(
+            model_name=model_name,
+            api_key=api_key,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            base_url=base_url,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         self.logger.setLevel(logging.INFO)
-        self.temperature = temperature
-        self.max_tokens = max_tokens
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         self.base_url = base_url or os.getenv(
             "OPENAI_BASE_URL", "https://api.openai.com/v1"
         )

--- a/minions/clients/openrouter.py
+++ b/minions/clients/openrouter.py
@@ -20,6 +20,7 @@ class OpenRouterClient(OpenAIClient):
         temperature: float = 0.0,
         max_tokens: int = 4096,
         base_url: Optional[str] = None,
+        **kwargs
     ):
         """Initialize the OpenRouter client.
 
@@ -29,6 +30,7 @@ class OpenRouterClient(OpenAIClient):
             temperature: Temperature parameter for generation.
             max_tokens: Maximum number of tokens to generate.
             base_url: Base URL for the OpenRouter API. If not provided, will look for OPENROUTER_BASE_URL env var or use default.
+            **kwargs: Additional parameters passed to base class
         """
         # Get API key from environment if not provided
         if api_key is None:
@@ -41,13 +43,15 @@ class OpenRouterClient(OpenAIClient):
         # Get base URL from parameter, environment variable, or use default
         base_url = base_url or os.environ.get("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
 
-        # Initialize the OpenAI client with the OpenRouter base URL
-        self.client = OpenAI(api_key=api_key, base_url=base_url)
-        self.model_name = model_name
-        self.temperature = temperature
-        self.max_tokens = max_tokens
-        self.logger = logging.getLogger("OpenRouterClient")
-        self.logger.setLevel(logging.INFO)
+        # Call parent constructor
+        super().__init__(
+            model_name=model_name,
+            api_key=api_key,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            base_url=base_url,
+            **kwargs
+        )
 
     def chat(self, messages: List[Dict[str, Any]], **kwargs) -> Tuple[List[str], Usage]:
         """

--- a/minions/clients/perplexity.py
+++ b/minions/clients/perplexity.py
@@ -4,9 +4,10 @@ import os
 import openai
 
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 
 
-class PerplexityAIClient:
+class PerplexityAIClient(MinionsClient):
     def __init__(
         self,
         model_name: str = "sonar-pro",
@@ -14,24 +15,31 @@ class PerplexityAIClient:
         temperature: float = 0.0,
         max_tokens: int = 4096,
         base_url: Optional[str] = None,
+        **kwargs
     ):
         """
         Initialize the Perplexity client.
 
         Args:
-            model_name: The name of the model to use (default: "sonar")
+            model_name: The name of the model to use (default: "sonar-pro")
             api_key: Perplexity API key (optional, falls back to environment variable if not provided)
             temperature: Sampling temperature (default: 0.0)
             max_tokens: Maximum number of tokens to generate (default: 4096)
             base_url: Base URL for the Perplexity API (optional, falls back to PERPLEXITY_BASE_URL environment variable or default URL)
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
+        super().__init__(
+            model_name=model_name,
+            api_key=api_key,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            base_url=base_url,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         openai.api_key = api_key or os.getenv("PERPLEXITY_API_KEY")
         self.api_key = openai.api_key
-        self.logger = logging.getLogger("PerplexityAIClient")
-        self.logger.setLevel(logging.INFO)
-        self.temperature = temperature
-        self.max_tokens = max_tokens
         
         # Get base URL from parameter, environment variable, or use default
         base_url = base_url or os.getenv("PERPLEXITY_BASE_URL", "https://api.perplexity.ai")

--- a/minions/clients/sambanova.py
+++ b/minions/clients/sambanova.py
@@ -1,11 +1,12 @@
 from typing import Any, Dict, List, Optional, Tuple
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 import logging
 import os
 import openai
 
 
-class SambanovaClient:
+class SambanovaClient(MinionsClient):
     def __init__(
         self,
         model_name: str = "Meta-Llama-3.1-8B-Instruct",
@@ -13,6 +14,7 @@ class SambanovaClient:
         temperature: float = 0.0,
         max_tokens: int = 4096,
         base_url: str = "https://api.sambanova.ai/v1",
+        **kwargs
     ):
         """
         Initialize the SambaNova client.
@@ -23,13 +25,19 @@ class SambanovaClient:
             temperature: Sampling temperature (default: 0.0)
             max_tokens: Maximum number of tokens to generate (default: 4096)
             base_url: SambaNova API base URL (default: "https://api.sambanova.ai/v1")
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
+        super().__init__(
+            model_name=model_name,
+            api_key=api_key,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            base_url=base_url,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         self.api_key = api_key or os.getenv("SAMBANOVA_API_KEY")
-        self.logger = logging.getLogger("SambanovaClient")
-        self.logger.setLevel(logging.INFO)
-        self.temperature = temperature
-        self.max_tokens = max_tokens
         self.base_url = base_url
 
     def chat(self, messages: List[Dict[str, Any]], **kwargs) -> Tuple[List[str], Usage]:

--- a/minions/clients/sarvam.py
+++ b/minions/clients/sarvam.py
@@ -4,9 +4,10 @@ import os
 import requests
 
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 
 
-class SarvamClient:
+class SarvamClient(MinionsClient):
     def __init__(
         self,
         model_name: str = "sarvam-m",
@@ -16,6 +17,7 @@ class SarvamClient:
         top_p: float = 1.0,
         n: int = 1,
         base_url: Optional[str] = None,
+        **kwargs
     ):
         """
         Initialize the Sarvam AI client.
@@ -28,13 +30,19 @@ class SarvamClient:
             top_p: Top-p sampling parameter (default: 1.0)
             n: Number of completions to generate (default: 1)
             base_url: Base URL for the Sarvam API (optional, falls back to SARVAM_BASE_URL environment variable or default URL)
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
+        super().__init__(
+            model_name=model_name,
+            api_key=api_key,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            base_url=base_url,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         self.api_key = api_key or os.getenv("SARVAM_API_KEY")
-        self.logger = logging.getLogger("SarvamClient")
-        self.logger.setLevel(logging.INFO)
-        self.temperature = temperature
-        self.max_tokens = max_tokens
         self.top_p = top_p
         self.n = n
         self.base_url = base_url or os.getenv(

--- a/minions/clients/secure.py
+++ b/minions/clients/secure.py
@@ -8,6 +8,7 @@ import os
 from typing import List, Dict, Any, Optional, Tuple
 
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 
 # Import crypto utilities from secure module
 try:
@@ -26,7 +27,7 @@ except ImportError:
     logging.warning("Secure crypto utilities not available. SecureClient will not function properly.")
 
 
-class SecureClient:
+class SecureClient(MinionsClient):
     def __init__(
         self,
         endpoint_url: str,
@@ -36,6 +37,7 @@ class SecureClient:
         timeout: int = 30,
         verify_attestation: bool = True,
         session_timeout: int = 3600,  # 1 hour default session timeout
+        **kwargs
     ):
         """
         Initialize the Secure Client for encrypted communication with secure endpoints.
@@ -48,7 +50,16 @@ class SecureClient:
             timeout: Request timeout in seconds (default: 30)
             verify_attestation: Whether to verify endpoint attestation (default: True)
             session_timeout: Session timeout in seconds (default: 3600)
+            **kwargs: Additional parameters passed to base class
         """
+        super().__init__(
+            model_name=model_name,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         if not CRYPTO_AVAILABLE:
             raise ImportError(
                 "Secure crypto utilities are required for SecureClient. "

--- a/minions/clients/together.py
+++ b/minions/clients/together.py
@@ -4,15 +4,17 @@ import os
 from together import Together
 
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 
 
-class TogetherClient:
+class TogetherClient(MinionsClient):
     def __init__(
         self,
         model_name: str = "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
         api_key: Optional[str] = None,
         temperature: float = 0.0,
         max_tokens: int = 2048,
+        **kwargs
     ):
         """
         Initialize the Together client.
@@ -22,13 +24,18 @@ class TogetherClient:
             api_key: Together API key (optional, falls back to environment variable if not provided)
             temperature: Sampling temperature (default: 0.0)
             max_tokens: Maximum number of tokens to generate (default: 2048)
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
+        super().__init__(
+            model_name=model_name,
+            api_key=api_key,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         self.api_key = api_key or os.getenv("TOGETHER_API_KEY")
-        self.logger = logging.getLogger("TogetherClient")
-        self.logger.setLevel(logging.INFO)
-        self.temperature = temperature
-        self.max_tokens = max_tokens
         self.client = Together(api_key=self.api_key)
 
     def chat(self, messages: List[Dict[str, Any]], **kwargs) -> Tuple[List[str], Usage, List[str]]:

--- a/minions/clients/tokasaurus.py
+++ b/minions/clients/tokasaurus.py
@@ -4,11 +4,12 @@ import os
 from openai import OpenAI
 
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 from minions.clients.utils import ServerMixin
 
 
 # TODO: define one dataclass for what is returned from all the clients
-class TokasaurusClient(ServerMixin):
+class TokasaurusClient(MinionsClient, ServerMixin):
     def __init__(
         self,
         model_name: str = "meta-llama/Llama-3.2-1B-Instruct",
@@ -17,6 +18,7 @@ class TokasaurusClient(ServerMixin):
         port: Optional[int] = None,
         capture_output: bool = False,
         base_url: Optional[str] = None,
+        **kwargs
     ):
         """
         Initialize the Tokasaurus client.
@@ -28,12 +30,17 @@ class TokasaurusClient(ServerMixin):
             port: Port to use for the server (optional, will find a free port if not provided)
             capture_output: Whether to capture server output (default: False)
             base_url: Base URL for the Tokasaurus API (optional, falls back to TOKASAURUS_BASE_URL environment variable or default URL)
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
-        self.logger = logging.getLogger("OpenAIClient")
-        self.logger.setLevel(logging.INFO)
-        self.temperature = temperature
-        self.max_tokens = max_tokens
+        super().__init__(
+            model_name=model_name,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            base_url=base_url,
+            **kwargs
+        )
+        
+        # Client-specific configuration
 
         if port is None:
             self.port = self.find_free_port()

--- a/minions/clients/transformers.py
+++ b/minions/clients/transformers.py
@@ -32,9 +32,10 @@ except ImportError:
     )
 
 from minions.usage import Usage
+from minions.clients.base import MinionsClient
 
 
-class TransformersClient:
+class TransformersClient(MinionsClient):
     def __init__(
         self,
         model_name: str = "mistralai/Mistral-7B-v0.1",
@@ -46,6 +47,7 @@ class TransformersClient:
         tool_calling: bool = False,
         embedding_model: Optional[str] = None,
         enable_thinking: bool = False,  # for qwen models
+        **kwargs
     ):
         """
         Initialize the Transformers client for local HuggingFace models.
@@ -60,12 +62,17 @@ class TransformersClient:
             hf_token: Optional Hugging Face token for accessing gated models
             tool_calling: Whether to support tool calling (default: False)
             embedding_model: Optional separate model for embeddings (default: None, uses main model)
+            enable_thinking: Whether to enable thinking mode for qwen models (default: False)
+            **kwargs: Additional parameters passed to base class
         """
-        self.model_name = model_name
-        self.logger = logging.getLogger("TransformersClient")
-        self.logger.setLevel(logging.INFO)
-        self.temperature = temperature
-        self.max_tokens = max_tokens
+        super().__init__(
+            model_name=model_name,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs
+        )
+        
+        # Client-specific configuration
         self.top_p = top_p
         self.do_sample = do_sample
         self.hf_token = hf_token or os.environ.get("HF_TOKEN")


### PR DESCRIPTION
Introduces `MinionsClient` abstract base class and refactors all existing clients to inherit from it, establishing an interface while maintaining 100% backward compatibility; the class provides common initialization for `model_name`, `temperature`, `max_tokens`, `api_key`, `base_url`, and `verbose`, and defines an abstract `chat()` method that all clients must implement, with each client updated to call `super().__init__()` with appropriate parameters.
