### PR TITLE
Extend Lemonade Server API Integration to Minions (Plural) with GGUF Model, Forced Output Schema, and Parallel Processing Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ We support three servers for running local models: `lemonade`, `ollama`, and `to
 - You should use `lemonade` if you have access to local AMD CPUs/GPUs/NPUs. Install `lemonade` following the instructions [here](https://lemonade-server.ai/).
     - See the following for supported APU configurations: https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-configurations
     - After installing `lemonade` make sure to launch the lemonade server. This can be done via the [one-click Windows GUI](https://lemonade-server.ai/) installer which installs the Lemonade Server as a standalone tool.
-    - Note: Lemonade support is currently experimental and only supports the Minion protocol at this time. 
+    - Note: Lemonade support is currently experimental and only supports the Minion/Minions protocol at this time. 
 - You should use `tokasaurus` if you have access to NVIDIA GPUs and you are running the Minions protocol, which benefits from the high-throughput of `tokasaurus`. Install `tokasaurus` with the following command:
 ```
 pip install tokasaurus

--- a/app.py
+++ b/app.py
@@ -1876,7 +1876,7 @@ with st.sidebar:
         "SambaNova",
         "LlamaAPI",
     ]:  # Added LlamaAPI and Anthropic to the list
-        # Currently Lemonade does not support Minion-CUA
+        # Currently Lemonade only supports the Minion and Minions protocols
         # TODO: Once more protocol support is added to the
         # Lemonade client, remove this check
         if local_provider == "Lemonade":

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import time
+import traceback
 
 from minions.minion import Minion
 from minions.minions import Minions
@@ -622,6 +623,8 @@ def initialize_clients(
                 model_name=local_model_name,
                 temperature=local_temperature,
                 max_tokens=int(local_max_tokens),
+                structured_output_schema=StructuredLocalOutput,
+                use_async=use_async,
             )
         elif local_provider == "Distributed Inference":
             server_url = st.session_state.get(
@@ -695,6 +698,8 @@ def initialize_clients(
                 model_name=local_model_name,
                 temperature=local_temperature,
                 max_tokens=int(local_max_tokens),
+                structured_output_schema=None,
+                use_async=use_async,
             )
         elif local_provider == "Distributed Inference":
             server_url = st.session_state.get(
@@ -1036,6 +1041,8 @@ def run_protocol(
                             model_name=st.session_state.local_model_name,
                             temperature=st.session_state.local_temperature,
                             max_tokens=int(st.session_state.local_max_tokens),
+                            structured_output_schema=None,  # Minion protocol doesn't use structured output
+                            use_async=False,  # Minion protocol doesn't use async
                         )
                     elif local_provider == "Distributed Inference":
                         server_url = st.session_state.get(
@@ -1869,11 +1876,14 @@ with st.sidebar:
         "SambaNova",
         "LlamaAPI",
     ]:  # Added LlamaAPI and Anthropic to the list
-        # Currently Lemonade only supports Minion protocol
+        # Currently Lemonade does not support Minion-CUA
         # TODO: Once more protocol support is added to the
         # Lemonade client, remove this check
         if local_provider == "Lemonade":
-            protocol_options = ["Minion"]
+            protocol_options = [
+                "Minion",
+                "Minions"
+            ]
         else:
             protocol_options = [
                 "Minion",
@@ -2052,26 +2062,43 @@ with st.sidebar:
                 "Qwen/Qwen2.5-1.5B-Instruct": "Qwen/Qwen2.5-1.5B-Instruct",
             }
         elif local_provider == "Lemonade":
+            # Check if this is for Minion or Minions - Minions can only use GGUF models
             lemonade = LemonadeClient()
             available_lemonade_models = lemonade.get_available_models()
-
-            local_model_options = {
-                "Llama-3.2-3B-Instruct-Hybrid": "Llama-3.2-3B-Instruct-Hybrid",
-                "Qwen2.5-0.5B-Instruct-CPU": "Qwen2.5-0.5B-Instruct-CPU",
-                "Llama-3.2-1B-Instruct-Hybrid": "Llama-3.2-1B-Instruct-Hybrid",
-                "Phi-3-Mini-Instruct-Hybrid": "Phi-3-Mini-Instruct-Hybrid",
-                "Qwen-1.5-7B-Chat-Hybrid": "Qwen-1.5-7B-Chat-Hybrid",
-                "DeepSeek-R1-Distill-Llama-8B-Hybrid": "DeepSeek-R1-Distill-Llama-8B-Hybrid",
-                "DeepSeek-R1-Distill-Qwen-7B-Hybrid": "DeepSeek-R1-Distill-Qwen-7B-Hybrid",
-            }
+            if protocol == "Minions":
+                local_model_options = {
+                    "Qwen3-8B-GGUF": "Qwen3-8B-GGUF",
+                    "Qwen3-4B-GGUF": "Qwen3-4B-GGUF",
+                    "Qwen3-1.7B-GGUF": "Qwen3-1.7B-GGUF",
+                    "Qwen3-0.6B-GGUF": "Qwen3-0.6B-GGUF",
+                    "DeepSeek-Qwen3-8B-GGUF": "DeepSeek-Qwen3-8B-GGUF",
+                    "Gemma-3-4b-it-GGUF": "Gemma-3-4b-it-GGUF",
+                    "Qwen2.5-VL-7B-Instruct-GGUF": "Qwen2.5-VL-7B-Instruct-GGUF"
+                }
+            else:
+                local_model_options = {
+                    "Llama-3.2-3B-Instruct-Hybrid": "Llama-3.2-3B-Instruct-Hybrid",
+                    "Qwen2.5-0.5B-Instruct-CPU": "Qwen2.5-0.5B-Instruct-CPU",
+                    "Llama-3.2-1B-Instruct-Hybrid": "Llama-3.2-1B-Instruct-Hybrid",
+                    "Phi-3-Mini-Instruct-Hybrid": "Phi-3-Mini-Instruct-Hybrid",
+                    "Qwen-1.5-7B-Chat-Hybrid": "Qwen-1.5-7B-Chat-Hybrid",
+                    "DeepSeek-R1-Distill-Llama-8B-Hybrid": "DeepSeek-R1-Distill-Llama-8B-Hybrid",
+                    "DeepSeek-R1-Distill-Qwen-7B-Hybrid": "DeepSeek-R1-Distill-Qwen-7B-Hybrid",
+                }
 
             # Add any additional available models from Lemonade that aren't in the default list
             if available_lemonade_models:
                 for model in available_lemonade_models:
                     model_key = model
-                    # Add the model if it's not already in the options
-                    if model not in local_model_options.values():
-                        local_model_options[model_key] = model
+                    # Check if the model must be GGUF to be added to the list
+                    if protocol == "Minions":
+                        # Add the GGUF model if it's not already in the options
+                        if model not in local_model_options.values() and "GGUF" in model.upper():
+                            local_model_options[model_key] = model
+                    else:
+                        # Add the model if it's not already in the options
+                        if model not in local_model_options.values():
+                            local_model_options[model_key] = model
         elif local_provider == "Distributed Inference":
             local_model_options = {
                 "auto (Let network choose) (Recommended)": "auto",
@@ -3078,3 +3105,5 @@ else:
 
             except Exception as e:
                 st.error(f"An error occurred: {str(e)}")
+                traceback.print_exc()
+

--- a/minions/clients/lemonade.py
+++ b/minions/clients/lemonade.py
@@ -105,6 +105,11 @@ class LemonadeClient(OpenAIClient):
         Accepts a list of message dicts or a single dict.
         Returns (responses, usage_total, done_reasons).
         """
+        if not self.use_async:
+            raise RuntimeError(
+                "This client is not in async mode. Set `use_async=True`."
+            )
+        
         if not AIOHTTP_AVAILABLE:
             raise ImportError("aiohttp is required for async Lemonade client. Please install with: pip install aiohttp")
         import asyncio

--- a/minions/clients/lemonade.py
+++ b/minions/clients/lemonade.py
@@ -18,8 +18,8 @@ import asyncio
 
 class LemonadeClient(OpenAIClient):
     """
-    Hybrid client: uses llama-cpp-python backend for forced schema output,
-    otherwise uses Lemonade server API.
+    Uses Lemonade API Server to run local clients in Minion and/or Minions Protocol.
+    Lemonade is still experimental, more protocols will be integrated soon.
     """
 
     def __init__(
@@ -101,8 +101,9 @@ class LemonadeClient(OpenAIClient):
         **kwargs,
     ) -> Tuple[List[str], Usage, List[str]]:
         """
-        Parallel asynchronous chat for Lemonade, matching Ollama's achat.
+        Parallel asynchronous chat for Lemonade.
         Accepts a list of message dicts or a single dict.
+        This is only used for the Minions protocol.
         Returns (responses, usage_total, done_reasons).
         """
         if not self.use_async:

--- a/tests/test_minions_lemonade.py
+++ b/tests/test_minions_lemonade.py
@@ -1,0 +1,42 @@
+from minions.clients.lemonade import LemonadeClient
+from minions.clients.openai import OpenAIClient
+from minions.minions import Minions
+from pydantic import BaseModel
+
+# Define the structured output schema for local client
+class StructuredLocalOutput(BaseModel):
+    explanation: str
+    citation: str | None
+    answer: str | None
+
+# Instantiate the local Lemonade client (make sure Lemonade server is running with GGUF model)
+local_client = LemonadeClient(
+    model_name="Qwen3-8B-GGUF",  # Must be a GGUF model
+    temperature=0.0,
+    max_tokens=2048,
+    structured_output_schema=StructuredLocalOutput,
+    use_async=True,
+)
+
+# Instantiate the remote OpenAI client
+remote_client = OpenAIClient(
+    model_name="gpt-4o",
+)
+
+# Instantiate the Minions protocol with both clients
+minions = Minions(local_client, remote_client)
+
+context = """
+Patient John Doe is a 60-year-old male with a history of hypertension. In his latest checkup, his blood pressure was recorded at 160/100 mmHg, and he reported occasional chest discomfort during physical activity.
+Recent laboratory results show that his LDL cholesterol level is elevated at 170 mg/dL, while his HDL remains within the normal range at 45 mg/dL. Other metabolic indicators, including fasting glucose and renal function, are unremarkable.
+"""
+
+task = "Based on the patient's blood pressure and LDL cholesterol readings in the context, evaluate whether these factors together suggest an increased risk for cardiovascular complications."
+
+# Execute the minions protocol for up to two communication rounds
+output = minions(
+    task=task,
+    doc_metadata="Medical Report",
+    context=[context],
+    max_rounds=2
+)


### PR DESCRIPTION
**Overview**
Minions (plural) protocol integration into Lemonade. This introduces several enhancements for local LLM usage based on this [Lemonade PR](https://github.com/lemonade-sdk/lemonade/pull/46) adding a response_format on Llama.cpp that should be included in Lemonade v8.0.2.

- **Lemonade Server API Support for Minions (Plural):** Minions can now orchestrate multiple local LLMs via Lemonade's OpenAI-compatible REST endpoints.

- **GGUF Model Compatibility:** Enables Minions to use GGUF models through Lemonade's Llama.cpp backend, supporting efficient, quantized inference on local hardware.

- **Forced Output Schema:** Adds the ability to enforce structured outputs (e.g., JSON) by specifying output schemas for Minions, improving integration and reliability.

- **Parallel Processing:** Implements parallel execution of subtasks across multiple Minions, increasing efficiency and reducing latency for batch and context-chunked tasks.