### PR TITLE
Add DeepResearch Support & MCP Testing to LemonadeClient

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ from minions.utils.app_utils import render_deep_research_ui
 from minions.utils.firecrawl_util import scrape_url
 from minions.minion_cua import MinionCUA, KEYSTROKE_ALLOWED_APPS, SAFE_WEBSITE_DOMAINS
 from minions.utils.inference_estimator import InferenceEstimator
+from minions.minions_deep_research import JobOutput as DeepResearchJobOutput
 
 
 # Instead of trying to import at startup, set voice_generation_available to None
@@ -701,11 +702,12 @@ def initialize_clients(
                 verbose=modular_verbose,
             )
         elif local_provider == "Lemonade":
+            structured_output_schema = DeepResearchJobOutput if protocol == "DeepResearch" else None
             st.session_state.local_client = LemonadeClient(
                 model_name=local_model_name,
                 temperature=local_temperature,
                 max_tokens=int(local_max_tokens),
-                structured_output_schema=None,
+                structured_output_schema=structured_output_schema,
                 use_async=use_async,
             )
         elif local_provider == "Distributed Inference":
@@ -1890,7 +1892,8 @@ with st.sidebar:
             protocol_options = [
                 "Minion",
                 "Minions",
-                "Minions-MCP"
+                "Minions-MCP",
+                "DeepResearch"
             ]
         else:
             protocol_options = [
@@ -2073,7 +2076,7 @@ with st.sidebar:
             # Check if this is for Minion or Minions - Minions can only use GGUF models
             lemonade = LemonadeClient()
             available_lemonade_models = lemonade.get_available_models()
-            if protocol == "Minions" or "Minions-MCP":
+            if protocol in ("Minions", "Minions-MCP", "DeepResearch"):
                 local_model_options = {
                     "Qwen3-8B-GGUF": "Qwen3-8B-GGUF",
                     "Qwen3-4B-GGUF": "Qwen3-4B-GGUF",
@@ -2099,7 +2102,7 @@ with st.sidebar:
                 for model in available_lemonade_models:
                     model_key = model
                     # Check if the model must be GGUF to be added to the list
-                    if protocol == "Minions":
+                    if protocol in ("Minions", "Minions-MCP", "DeepResearch"):
                         # Add the GGUF model if it's not already in the options
                         if model not in local_model_options.values() and "GGUF" in model.upper():
                             local_model_options[model_key] = model

--- a/mcp.json
+++ b/mcp.json
@@ -11,7 +11,7 @@
 	"calculator": {
       		"command": "python",
       		"args": [
-        		"C:\\Users\\Edan\\Downloads\\mcp_calculator.py"
+        		"./tests/mcp_server_example/calculator_mcp_server_example.py"
       		]
     	}
     }

--- a/minions/clients/lemonade.py
+++ b/minions/clients/lemonade.py
@@ -66,11 +66,9 @@ class LemonadeClient(OpenAIClient):
 
     def schat(self, messages: List[Dict[str, Any]], **kwargs) -> Tuple[List[str], Usage, List[str]]:
         """
-        Synchronous chat: used for Minion. This assumes structured_output_schema is not used here.
+        Synchronous chat: used for Minion and DeepResearch.
         """
         assert len(messages) > 0, "Messages cannot be empty."
-        if self.structured_output_schema is not None:
-            raise TypeError("Lemonade does not currently support this configuration. Forced output schema isn't available in synchronous chats.")
         payload = {
             "model": self.model_name,
             "messages": messages,
@@ -78,6 +76,15 @@ class LemonadeClient(OpenAIClient):
             "temperature": self.temperature,
             **kwargs,
         }
+        # Check if there is a structured output - for DeepResearch only
+        if self.structured_output_schema:
+            try:
+                payload["response_format"] = {
+                    "type": "json_object",
+                    "schema": self.structured_output_schema.model_json_schema()
+                }
+            except Exception as e:
+                raise RuntimeError(f"Failed to generate schema for structured_output_schema: {e}")
         response = self.session.post(
             f"{self.base_url.rstrip('/api/v1')}/api/v1/chat/completions",
             json=payload,

--- a/minions/minions_deep_research.py
+++ b/minions/minions_deep_research.py
@@ -8,7 +8,7 @@ from minions.minions import Minions, chunk_by_section
 from minions.utils.firecrawl_util import scrape_url
 from minions.utils.serpapi_util import get_web_urls
 from minions.prompts.minions_deep_research import WORKER_SUMMARIZE_PROMPT, INITIAL_QUERY_PROMPT, ASSESSMENT_PROMPT, FINAL_SYNTHESIS_PROMPT
-
+from minions.clients import LemonadeClient
 class JobManifest(BaseModel):
     """
     Represents a job manifest for a Minions Deep Researchtask
@@ -316,7 +316,9 @@ class DeepResearchMinions:
         prompt = FINAL_SYNTHESIS_PROMPT.format(query=query, information=formatted_summaries)
         try: 
             responses, usage, done_reasons = self.local_client.chat([{"role": "user", "content": prompt}])
-            return responses[0], visited_urls
+            print(responses[0])
+            final_response = json.loads(responses[0])["explanation"] if isinstance(self.local_client, LemonadeClient) else responses[0]
+            return final_response, visited_urls
         except Exception as e:
             print(f"[Deep Research Minions] [Synthesize Final Response] Error in synthesize_final_response: {e}")
             return "An error occurred while synthesizing the final response.", []

--- a/minions/minions_deep_research.py
+++ b/minions/minions_deep_research.py
@@ -316,7 +316,6 @@ class DeepResearchMinions:
         prompt = FINAL_SYNTHESIS_PROMPT.format(query=query, information=formatted_summaries)
         try: 
             responses, usage, done_reasons = self.local_client.chat([{"role": "user", "content": prompt}])
-            print(responses[0])
             final_response = json.loads(responses[0])["explanation"] if isinstance(self.local_client, LemonadeClient) else responses[0]
             return final_response, visited_urls
         except Exception as e:

--- a/tests/mcp_server_example/calculator_mcp_server_example.py
+++ b/tests/mcp_server_example/calculator_mcp_server_example.py
@@ -1,0 +1,47 @@
+import sys
+import traceback
+
+print(">>> [DEBUG] mcp_calculator.py starting", file=sys.stderr, flush=True)
+
+try:
+    # Use FastMCP as the server interface
+    from mcp.server.fastmcp import FastMCP
+
+    # Create the MCP server instance
+    mcp = FastMCP("Calculator Server")
+
+    # --- Define your calculator tool functions here ---
+
+    @mcp.tool(description="Add two numbers")
+    def add(a: float, b: float) -> float:
+        """Add two numbers and return the result."""
+        return a + b
+
+    @mcp.tool(description="Subtract b from a")
+    def subtract(a: float, b: float) -> float:
+        """Subtract b from a and return the result."""
+        return a - b
+
+    @mcp.tool(description="Multiply two numbers")
+    def multiply(a: float, b: float) -> float:
+        """Multiply two numbers and return the result."""
+        return a * b
+
+    @mcp.tool(description="Divide a by b")
+    def divide(a: float, b: float) -> float:
+        """Divide a by b and return the result. Returns error if b is zero."""
+        if b == 0:
+            raise ValueError("Division by zero is not allowed.")
+        return a / b
+
+    print(">>> [DEBUG] Calculator tools registered", file=sys.stderr, flush=True)
+
+    # --- Start the server ---
+    if __name__ == "__main__":
+        print(">>> [DEBUG] Running FastMCP server", file=sys.stderr, flush=True)
+        mcp.run()  # FastMCP auto-detects stdio when run as a subprocess
+
+except Exception as e:
+    print(f">>> [ERROR] Exception in mcp_calculator.py: {e}", file=sys.stderr, flush=True)
+    traceback.print_exc(file=sys.stderr)
+    sys.exit(1)

--- a/tests/test_deepresearch_lemonade.py
+++ b/tests/test_deepresearch_lemonade.py
@@ -1,0 +1,40 @@
+from minions.clients.lemonade import LemonadeClient
+from minions.clients.openai import OpenAIClient
+from minions.minions_deep_research import DeepResearchMinions, JobOutput
+
+# Initialize Lemonade as the local client (sync mode, GGUF model recommended for best results)
+local_client = LemonadeClient(
+    model_name="Qwen3-8B-GGUF",
+    temperature=0.2,
+    max_tokens=2048,
+    structured_output_schema=JobOutput,
+    use_async=False  # DeepResearchMinions uses sync by default
+)
+
+# Initialize OpenAI as the remote client
+remote_client = OpenAIClient(
+    model_name="gpt-4o"
+)
+
+# Instantiate DeepResearchMinions with both clients
+minion = DeepResearchMinions(
+    local_client=local_client,
+    remote_client=remote_client,
+    max_rounds=3,
+    max_sources_per_round=5
+)
+
+# Example research query
+query = (
+    "Explain how Anthropic's MCP works?"
+)
+
+# Run the DeepResearch protocol
+if __name__ == "__main__":
+    output, visited_urls = minion(
+        query=query,
+    )
+    print("=== DeepResearch Output ===")
+    print(output)
+    print("\nVisited URLs:")
+    print(visited_urls)

--- a/tests/test_minions_mcp.py
+++ b/tests/test_minions_mcp.py
@@ -12,7 +12,7 @@ class StructuredLocalOutput(BaseModel):
     answer: str | None
 
 
-test_lemonade = False
+test_lemonade = True
 
 if test_lemonade:
     # Option 1: Lemonade
@@ -33,7 +33,7 @@ else:
 remote_client = OpenAIClient(model_name="gpt-4o", temperature=0.0)
 
 # Get MCP config path from environment or use default
-mcp_config_path = "C:\\Users\\Edan\\minions\\mcp.json"
+mcp_config_path = "..\\..\\mcp.json"
 
 try:
     # Create SyncMinionsMCP instance


### PR DESCRIPTION
**Overview**
This PR brings a few nice improvements for working with MCP and LemonadeClient:

**What’s New**

- **DeepResearch Functionality:** The LemonadeClient now has full DeepResearch support! You can run advanced research tasks locally through Lemonade, making it much more versatile.

- **MCP Test for Lemonade:** I’ve set up a proper test file to make sure the MCP (Multi-Component Protocol) workflow plays nicely with Lemonade.

- **Calculator MCP Server Example:** For anyone looking to get started or test things out, I’ve included a simple calculator MCP server. It’s a straightforward example you can use as a reference or starting point for your own MCP servers.