### PR TITLE
fix: use 127.0.0.1 in curl examples to avoid IPv6 issues

### DIFF
--- a/apps/minions-docker/README.md
+++ b/apps/minions-docker/README.md
@@ -46,12 +46,12 @@ Set these environment variables or pass them via the `/start_protocol` endpoint:
 
 #### Check Health
 ```bash
-curl http://localhost:5000/health
+curl http://127.0.0.1:5000/health
 ```
 
 #### Initialize Protocol
 ```bash
-curl -X POST http://localhost:5000/start_protocol \
+curl -X POST http://127.0.0.1:5000/start_protocol \
   -H "Content-Type: application/json" \
   -d '{
     "openai_api_key": "YOUR-API-KEY",
@@ -64,7 +64,7 @@ curl -X POST http://localhost:5000/start_protocol \
 
 #### Run Query
 ```bash
-curl -X POST http://localhost:5000/run \
+curl -X POST http://127.0.0.1:5000/run \
   -H "Content-Type: application/json" \
   -d '{
     "query": "What is the main topic of this text?",
@@ -75,10 +75,10 @@ curl -X POST http://localhost:5000/run \
 #### Get/Update Configuration
 ```bash
 # Get current configuration
-curl http://localhost:5000/config
+curl http://127.0.0.1:5000/config
 
 # Update configuration
-curl -X POST http://localhost:5000/config \
+curl -X POST http://127.0.0.1:5000/config \
   -H "Content-Type: application/json" \
   -d '{
     "max_rounds": 5,


### PR DESCRIPTION
On macOS, the ControlCe process listens on port 5000 over ::1 (IPv6).
As a result, using curl with 'localhost' can resolve to ::1 and hit ControlCe instead of the
Docker container, resulting in unexpected 403 Forbidden responses.

To avoid this issue and ensure cross-platform compatibility, all curl examples in the README have been updated to use 127.0.0.1 explicitly.