### PR TITLE
fix: correct client registry exports

### DIFF
--- a/minions/clients/__init__.py
+++ b/minions/clients/__init__.py
@@ -62,7 +62,6 @@ __all__ = [
     "NotDiamondAIClient",
     "VercelGatewayClient",
     "ExaClient",
-    "BasetenClient",
     "NousResearchClient",
 ]
 
@@ -87,7 +86,7 @@ except ImportError:
     )
 
 try:
-    from .huggingface_client import HuggingFaceClient
+    from .huggingface import HuggingFaceClient
 
     __all__.append("HuggingFaceClient")
 except ImportError:


### PR DESCRIPTION
## Summary
- Fixes the HuggingFace client import path in `minions/clients/__init__.py`.
- Removes `BasetenClient` from `__all__` because no corresponding client implementation is present.
- Keeps the exported client registry aligned with available client modules.

## Validation
- Verified the registry mismatch statically by checking `minions/clients/`.
- Attempted targeted import smoke test, but local import was blocked by missing optional dependencies (`together` after installing `ollama`; full `pip install -e .` not run due to heavy deps such as `torch`).
- The patch only updates the registry to match existing source files.

## Notes
- This is intentionally scoped as a small registry consistency fix.
